### PR TITLE
Rename mount to tcp variable

### DIFF
--- a/config/moveit_grasps_config.yaml
+++ b/config/moveit_grasps_config.yaml
@@ -33,7 +33,7 @@ moveit_grasps:
     # Collision checking in verbose on second pass (after all failed)
     show_grasp_filter_collision_if_failed: false
     # Show post-filter arrows
-    show_filtered_grasps: true
+    show_filtered_grasps: false
     # Show pose-filter arm ik solutions
     show_filtered_arm_solutions: false
     show_filtered_arm_solutions_pregrasp_speed: 0.01

--- a/config/moveit_grasps_config.yaml
+++ b/config/moveit_grasps_config.yaml
@@ -33,7 +33,7 @@ moveit_grasps:
     # Collision checking in verbose on second pass (after all failed)
     show_grasp_filter_collision_if_failed: false
     # Show post-filter arrows
-    show_filtered_grasps: false
+    show_filtered_grasps: true
     # Show pose-filter arm ik solutions
     show_filtered_arm_solutions: false
     show_filtered_arm_solutions_pregrasp_speed: 0.01

--- a/config_robot/panda_grasp_data.yaml
+++ b/config_robot/panda_grasp_data.yaml
@@ -11,7 +11,7 @@ hand:
 
     # min/max values of the grasp depth range in meter.
     # This should fit to the distance from finger tip to inner palm or the suction cup stroke
-    grasp_max_depth : 0.025
+    grasp_max_depth : 0.035
     grasp_min_depth : 0.01
     # grasp_depth_resolution is the discretization distance in meter used for sampling the grasp depth value.
     # Idealy this should be a small fraction of the depth range (i.e. 0.005).

--- a/config_robot/panda_grasp_data.yaml
+++ b/config_robot/panda_grasp_data.yaml
@@ -32,7 +32,7 @@ hand:
     # z-axis pointing toward object to grasp
     # x-axis perp. to movement of grippers
     # y-axis parallel to movement of grippers
-    grasp_pose_to_eef_transform :  [0, 0, -0.105, 0, 0, -0.7853] # NOTE: Imaginary point in the middle
+    eef_mount_to_tcp_transform :  [0, 0, -0.105, 0, 0, -0.7853] # NOTE: Imaginary point in the middle
 
     # Joint names and state values for the end effector.
     # The names should match the values of pregrasp_posture and grasp_posture.

--- a/config_robot/panda_grasp_data.yaml
+++ b/config_robot/panda_grasp_data.yaml
@@ -32,7 +32,7 @@ hand:
     # z-axis pointing toward object to grasp
     # x-axis perp. to movement of grippers
     # y-axis parallel to movement of grippers
-    eef_mount_to_tcp_transform :  [0, 0, 0.105, 0, 0, 0.7853] # NOTE: Imaginary point in the middle
+    tcp_to_eef_mount_transform :  [0, 0, -0.105, 0, 0, -0.7853] # NOTE: Imaginary point in the middle
 
     # Joint names and state values for the end effector.
     # The names should match the values of pregrasp_posture and grasp_posture.

--- a/config_robot/panda_grasp_data.yaml
+++ b/config_robot/panda_grasp_data.yaml
@@ -11,7 +11,7 @@ hand:
 
     # min/max values of the grasp depth range in meter.
     # This should fit to the distance from finger tip to inner palm or the suction cup stroke
-    grasp_max_depth : 0.035
+    grasp_max_depth : 0.025
     grasp_min_depth : 0.01
     # grasp_depth_resolution is the discretization distance in meter used for sampling the grasp depth value.
     # Idealy this should be a small fraction of the depth range (i.e. 0.005).
@@ -32,7 +32,7 @@ hand:
     # z-axis pointing toward object to grasp
     # x-axis perp. to movement of grippers
     # y-axis parallel to movement of grippers
-    eef_mount_to_tcp_transform :  [0, 0, -0.105, 0, 0, -0.7853] # NOTE: Imaginary point in the middle
+    eef_mount_to_tcp_transform :  [0, 0, 0.105, 0, 0, 0.7853] # NOTE: Imaginary point in the middle
 
     # Joint names and state values for the end effector.
     # The names should match the values of pregrasp_posture and grasp_posture.

--- a/include/moveit_grasps/grasp_data.h
+++ b/include/moveit_grasps/grasp_data.h
@@ -132,7 +132,7 @@ public:
   // A representation of the gripper type as an integer. See EndEffectorType for values
   EndEffectorType end_effector_type_;
 
-  Eigen::Isometry3d eef_mount_to_tcp_;  // Convert generic grasp pose to this end effector's frame of reference
+  Eigen::Isometry3d tcp_to_eef_mount_;  // Convert generic grasp pose to the parent arm's eef_mount frame of reference
   trajectory_msgs::JointTrajectory pre_grasp_posture_;  // when the end effector is in "open" position
   trajectory_msgs::JointTrajectory grasp_posture_;      // when the end effector is in "close" position
   std::string base_link_;                               // name of global frame with z pointing up

--- a/include/moveit_grasps/grasp_data.h
+++ b/include/moveit_grasps/grasp_data.h
@@ -132,7 +132,7 @@ public:
   // A representation of the gripper type as an integer. See EndEffectorType for values
   EndEffectorType end_effector_type_;
 
-  Eigen::Isometry3d grasp_pose_to_eef_pose_;  // Convert generic grasp pose to this end effector's frame of reference
+  Eigen::Isometry3d eef_mount_to_tcp_;  // Convert generic grasp pose to this end effector's frame of reference
   trajectory_msgs::JointTrajectory pre_grasp_posture_;  // when the end effector is in "open" position
   trajectory_msgs::JointTrajectory grasp_posture_;      // when the end effector is in "close" position
   std::string base_link_;                               // name of global frame with z pointing up

--- a/include/moveit_grasps/grasp_generator.h
+++ b/include/moveit_grasps/grasp_generator.h
@@ -250,12 +250,12 @@ public:
    * \param translation - translation to go from cuboid centroid to grasping location
    * \param corner_rotation - extra rotatation needed to align grasp pose as you move around the cuboid
    * \param num_radial_grasps - the number of grasps to generate around the corner
-   * \param grasp_poses - list of grasp poses generated
+   * \param grasp_poses_tcp - list of grasp poses generated
    * \return the number of poses generated
    */
   std::size_t addCornerGraspsHelper(Eigen::Isometry3d pose, double rotation_angles[3], Eigen::Vector3d translation,
                                     double corner_rotation, std::size_t num_radial_grasps,
-                                    std::vector<Eigen::Isometry3d>& grasp_poses);
+                                    std::vector<Eigen::Isometry3d>& grasp_poses_tcp);
 
   /**
    * \brief helper function for adding grasps along the face of a cuboid
@@ -265,12 +265,12 @@ public:
    * \param translation - translation to go from cuboid centroid to grasping location
    * \param alignment_rotation - extra rotatation needed to align grasp pose as you move around the cuboid
    * \param num_grasps - the number of grasps to generate around the corner
-   * \param grasp_poses - list of grasp poses generated
+   * \param grasp_poses_tcp - list of grasp poses generated
    * \return the number of poses generated
    */
   std::size_t addFaceGraspsHelper(Eigen::Isometry3d pose, double rotation_angles[3], Eigen::Vector3d translation,
                                   Eigen::Vector3d delta, double alignment_rotation, std::size_t num_grasps,
-                                  std::vector<Eigen::Isometry3d>& grasp_poses);
+                                  std::vector<Eigen::Isometry3d>& grasp_poses_tcp);
 
   /**
    * \brief helper function for adding grasps along the edges of the cuboid
@@ -280,12 +280,12 @@ public:
    * \param translation - translation to go from cuboid centroid to grasping location
    * \param alignment_rotation - extra rotatation needed to align grasp pose as you move around the cuboid
    * \param num_grasps - the number of grasps to generate around the corner
-   * \param grasp_poses - list of grasp poses generated
+   * \param grasp_poses_tcp - list of grasp poses generated
    * \return the number of poses generated
    */
   std::size_t addEdgeGraspsHelper(Eigen::Isometry3d cuboid_pose, double rotation_angles[3], Eigen::Vector3d translation,
                                   Eigen::Vector3d delta, double alignment_rotation, std::size_t num_grasps,
-                                  std::vector<Eigen::Isometry3d>& grasp_poses, double corner_rotation);
+                                  std::vector<Eigen::Isometry3d>& grasp_poses_tcp, double corner_rotation);
 
   /**
    * \brief helper function for determining if the grasp will intersect the cuboid
@@ -293,12 +293,12 @@ public:
    * \param depth - size of cuboid along x axis
    * \param width - size of cuboid along y axis
    * \param height - size of cuboid along z axis
-   * \param grasp_pose - pose of grasp
+   * \param grasp_pose_tcp - pose of grasp
    * \param grasp_data - data describing end effector
    * \return true if the grasp intersects the cuboid
    */
   bool graspIntersectionHelper(Eigen::Isometry3d cuboid_pose, double depth, double width, double height,
-                               Eigen::Isometry3d grasp_pose, const GraspDataPtr grasp_data);
+                               Eigen::Isometry3d grasp_pose_tcp, const GraspDataPtr grasp_data);
 
   /**
    * \brief helper function to test intersection of a line with a plane
@@ -313,7 +313,7 @@ public:
 
   /**
    * \brief creates grasp messages from the generated grasp poses
-   * \param pose - the grasp pose. (Note: this is the pose of the eef mount not the position of the tcp)
+   * \param grasp_pose_eef_mount - the grasp pose. (Note: this is the pose of the eef mount not the position of the tcp)
    * \param grasp_data data describing the end effector
    * \param grasp_candidates - list possible grasps
    * \param object_pose - pose of object to grasp
@@ -321,30 +321,30 @@ public:
    * \param object_width - In the case of finger grippers, the width of the object in the dimension betwen the fingers
    * \return true on success
    */
-  bool addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr grasp_data,
+  bool addGrasp(const Eigen::Isometry3d& grasp_pose_eef_mount, const GraspDataPtr grasp_data,
                 std::vector<GraspCandidatePtr>& grasp_candidates, const Eigen::Isometry3d& object_pose,
                 const Eigen::Vector3d& object_size, double object_width);
 
   /**
    * \brief Score the generated suction grasp poses
-   * \param grasp_pose - the pose of the grasp
+   * \param grasp_pose_tcp - the pose of the grasp
    * \param grasp_data - data describing the end effector
    * \param cuboid_pose - the pose of the object being grasped
    * \param object size - the extents of the object being grasped
    * \return a score with positive being better
    */
-  double scoreSuctionGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr& grasp_data,
+  double scoreSuctionGrasp(const Eigen::Isometry3d& grasp_pose_tcp, const GraspDataPtr& grasp_data,
                            const Eigen::Isometry3d& cuboid_pose, const Eigen::Vector3d& object_size);
 
   /**
    * \brief Score the generated finger grasp poses
-   * \param grasp_pose - the pose of the grasp
+   * \param grasp_pose_tcp - the grasp pose of the tcp
    * \param grasp_data - data describing the end effector
    * \param object_pose - the pose of the object being grasped
    * \param percent_open - percentage that the grippers are open. 0.0 -> grippers are at object width + padding
    * \return a score with positive being better
    */
-  double scoreFingerGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr& grasp_data,
+  double scoreFingerGrasp(const Eigen::Isometry3d& grasp_pose_tcp, const GraspDataPtr& grasp_data,
                           const Eigen::Isometry3d& object_pose, double percent_open);
 
   /**

--- a/include/moveit_grasps/grasp_generator.h
+++ b/include/moveit_grasps/grasp_generator.h
@@ -313,7 +313,7 @@ public:
 
   /**
    * \brief creates grasp messages from the generated grasp poses
-   * \param pose - the grasp pose. (Note: this is the pose of the grasp itself not the position of the eef)
+   * \param pose - the grasp pose. (Note: this is the pose of the eef mount not the position of the tcp)
    * \param grasp_data data describing the end effector
    * \param grasp_candidates - list possible grasps
    * \param object_pose - pose of object to grasp

--- a/include/moveit_grasps/grasp_scorer.h
+++ b/include/moveit_grasps/grasp_scorer.h
@@ -68,18 +68,18 @@ public:
 
   /**
    * \brief Scores each axis of the grasp based on its angle to the desired pose axis.
-   * \param grasp_pose - the pose of the end effector
+   * \param grasp_pose_tcp - the pose of the end effector
    * \param ideal_pose - the ideal grasp pose (ex: straight into the bin)
    * \return the unweighted scores:
    *         1.0 -> 0 degrees between grasp axis and desired axis,
    *         0.0 -> 180 degrees
    */
-  static Eigen::Vector3d scoreRotationsFromDesired(const Eigen::Isometry3d& grasp_pose,
+  static Eigen::Vector3d scoreRotationsFromDesired(const Eigen::Isometry3d& grasp_pose_tcp,
                                                    const Eigen::Isometry3d& ideal_pose);
 
   /**
    * \brief Score the grasp based on how far the object is from the palm of the hand
-   * \param grasp_pose - the pose of the end effector (not the eef mount)
+   * \param grasp_pose_tcpgrasp_pose_tcp - the pose of the end effector (not the eef mount)
    * \param grasp_data - pointer to grasp info
    * \param object_pose - the pose of the object being grasped
    * \param max_grasp_distance - the maximum acceptable distance from palm
@@ -92,34 +92,34 @@ public:
   // max_distance should be the length of the fingers minus some minimum amount that the fingers need to grip an object
   // since we don't know the distance from the centoid of the object to the edge of the object, this is set as an
   // arbitrary number given our target object set (i.e. I based it off of the cheese it box)
-  static double scoreDistanceToPalm(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr grasp_data,
+  static double scoreDistanceToPalm(const Eigen::Isometry3d& grasp_pose_tcp, const GraspDataPtr grasp_data,
                                     const Eigen::Isometry3d& object_pose, const double& min_grasp_distance,
                                     const double& max_grasp_distance);
 
   /**
    * \brief Score the grasp based on the translation values of the grasp pose
-   * \param grasp_pose - the pose of the end effector (not the eef mount)
+   * \param grasp_pose_tcp - the pose of the end effector (not the eef mount)
    * \param min_translations - the minimum translation values for all grasp poses
    * \param max_translations - the maximum translation values for all grasp poses
    * \return the unweighted scores:
    *         0.0 -> pose is at the minimum translation in that axis
    *         1.0 -> pose is at the maximum translation in that axis
    */
-  static Eigen::Vector3d scoreGraspTranslation(const Eigen::Isometry3d& grasp_pose,
+  static Eigen::Vector3d scoreGraspTranslation(const Eigen::Isometry3d& grasp_pose_tcp,
                                                const Eigen::Vector3d& min_translations,
                                                const Eigen::Vector3d& max_translations);
 
   /**
    * \brief Score the grasp based on the translation values of the grasp pose
-   * \param grasp_pose - the pose of the end effector (not the eef mount)
+   * \param grasp_pose_tcp - the pose of the end effector (not the eef mount)
    * \param ideal_pose - the ideal pose location
    * \return the unweighted scores:
    *         0.0 -> pose is at the ideal translation in that axis
    */
-  static Eigen::Vector3d scoreGraspTranslation(const Eigen::Isometry3d& grasp_pose,
+  static Eigen::Vector3d scoreGraspTranslation(const Eigen::Isometry3d& grasp_pose_tcp,
                                                const Eigen::Isometry3d& ideal_pose);
 
-  static Eigen::Vector2d scoreGraspOverhang(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr& grasp_data,
+  static Eigen::Vector2d scoreGraspOverhang(const Eigen::Isometry3d& grasp_pose_tcp, const GraspDataPtr& grasp_data,
                                             const Eigen::Isometry3d& object_pose, const Eigen::Vector3d& object_size,
                                             moveit_visual_tools::MoveItVisualToolsPtr visual_tools = NULL);
 };

--- a/src/demo/grasp_generator_demo.cpp
+++ b/src/demo/grasp_generator_demo.cpp
@@ -125,10 +125,10 @@ public:
     grasp_generator_->setIdealGraspPoseRPY(ideal_grasp_rpy);
 
     // Visualize the ideal grasp pose
-    grasp_visuals_->publishAxisLabeled(grasp_generator_->ideal_grasp_pose_, "IDEAL_GRASP_POSE");
-    visual_tools_->publishEEMarkers(grasp_generator_->ideal_grasp_pose_ * grasp_data_->eef_mount_to_tcp_, ee_jmg,
+    grasp_visuals_->publishAxisLabeled(grasp_generator_->ideal_grasp_pose_, "IDEAL_TCP_GRASP_POSE");
+    visual_tools_->publishEEMarkers(grasp_generator_->ideal_grasp_pose_ * grasp_data_->tcp_to_eef_mount_, ee_jmg,
                                     grasp_data_->grasp_posture_.points[0].positions, rviz_visual_tools::BLUE);
-    grasp_visuals_->publishAxisLabeled(grasp_generator_->ideal_grasp_pose_ * grasp_data_->eef_mount_to_tcp_,
+    grasp_visuals_->publishAxisLabeled(grasp_generator_->ideal_grasp_pose_ * grasp_data_->tcp_to_eef_mount_,
                                        "IDEAL EEF MOUNT POSE");
     visual_tools_->trigger();
 

--- a/src/demo/grasp_generator_demo.cpp
+++ b/src/demo/grasp_generator_demo.cpp
@@ -126,9 +126,9 @@ public:
 
     // Visualize the ideal grasp pose
     grasp_visuals_->publishAxisLabeled(grasp_generator_->ideal_grasp_pose_, "IDEAL_GRASP_POSE");
-    visual_tools_->publishEEMarkers(grasp_generator_->ideal_grasp_pose_ * grasp_data_->grasp_pose_to_eef_pose_, ee_jmg,
+    visual_tools_->publishEEMarkers(grasp_generator_->ideal_grasp_pose_ * grasp_data_->eef_mount_to_tcp_, ee_jmg,
                                     grasp_data_->grasp_posture_.points[0].positions, rviz_visual_tools::BLUE);
-    grasp_visuals_->publishAxisLabeled(grasp_generator_->ideal_grasp_pose_ * grasp_data_->grasp_pose_to_eef_pose_,
+    grasp_visuals_->publishAxisLabeled(grasp_generator_->ideal_grasp_pose_ * grasp_data_->eef_mount_to_tcp_,
                                        "IDEAL EEF MOUNT POSE");
     visual_tools_->trigger();
 

--- a/src/demo/grasp_pipeline_demo.cpp
+++ b/src/demo/grasp_pipeline_demo.cpp
@@ -222,8 +222,7 @@ public:
     // --------------------------------------------
     // Generating a seed state for filtering grasps
     robot_state::RobotStatePtr seed_state(new robot_state::RobotState(*visual_tools_->getSharedRobotState()));
-    Eigen::Isometry3d grasp_pose =
-        visual_tools_->convertPose(object_pose) * grasp_data_->grasp_pose_to_eef_pose_.inverse();
+    Eigen::Isometry3d grasp_pose = visual_tools_->convertPose(object_pose) * grasp_data_->eef_mount_to_tcp_.inverse();
     if (!getIKSolution(arm_jmg_, grasp_pose, *seed_state, grasp_data_->parent_link_->getName()))
     {
       ROS_WARN_STREAM_NAMED(LOGNAME, "The ideal seed state is not reachable. Using start state as seed.");

--- a/src/demo/grasp_pipeline_demo.cpp
+++ b/src/demo/grasp_pipeline_demo.cpp
@@ -222,8 +222,9 @@ public:
     // --------------------------------------------
     // Generating a seed state for filtering grasps
     robot_state::RobotStatePtr seed_state(new robot_state::RobotState(*visual_tools_->getSharedRobotState()));
-    Eigen::Isometry3d grasp_pose = visual_tools_->convertPose(object_pose) * grasp_data_->eef_mount_to_tcp_.inverse();
-    if (!getIKSolution(arm_jmg_, grasp_pose, *seed_state, grasp_data_->parent_link_->getName()))
+    Eigen::Isometry3d eef_mount_grasp_pose =
+        visual_tools_->convertPose(object_pose) * grasp_data_->tcp_to_eef_mount_.inverse();
+    if (!getIKSolution(arm_jmg_, eef_mount_grasp_pose, *seed_state, grasp_data_->parent_link_->getName()))
     {
       ROS_WARN_STREAM_NAMED(LOGNAME, "The ideal seed state is not reachable. Using start state as seed.");
     }

--- a/src/demo/grasp_poses_visualizer_demo.cpp
+++ b/src/demo/grasp_poses_visualizer_demo.cpp
@@ -128,35 +128,36 @@ public:
     // SHOW GRASP POSE
     visual_tools_->prompt("Press 'next' to show an example eef and grasp pose");
     ROS_INFO_STREAM_NAMED(name_, "Showing the grasp pose");
-    Eigen::Isometry3d grasp_pose = visual_tools_->convertPose(grasp_candidates_.front()->grasp_.grasp_pose.pose);
-    visual_tools_->publishAxis(grasp_pose, 0.05, 0.005);
-    Eigen::Isometry3d grasp_text_pose(grasp_pose);
+    Eigen::Isometry3d eef_mount_grasp_pose =
+        visual_tools_->convertPose(grasp_candidates_.front()->grasp_.grasp_pose.pose);
+    visual_tools_->publishAxis(eef_mount_grasp_pose, 0.05, 0.005);
+    Eigen::Isometry3d grasp_text_pose(eef_mount_grasp_pose);
     grasp_text_pose.translation().z() += 0.03;
     visual_tools_->publishText(grasp_text_pose, "Grasp Pose", rviz_visual_tools::WHITE, text_size, text);
-    visual_tools_->publishSphere(grasp_pose.translation(), rviz_visual_tools::LIME_GREEN, 0.01);
+    visual_tools_->publishSphere(eef_mount_grasp_pose.translation(), rviz_visual_tools::LIME_GREEN, 0.01);
     visual_tools_->trigger();
 
     // SHOW EE GRASP POSE
-    ROS_INFO_STREAM_NAMED(name_, "Showing ee grasp pose");
-    Eigen::Isometry3d ee_pose = grasp_pose * grasp_data_->eef_mount_to_tcp_.inverse();
-    visual_tools_->publishAxis(ee_pose, 0.05, 0.005);
-    Eigen::Isometry3d ee_text_pose(ee_pose);
-    ee_text_pose.translation().z() += 0.03;
-    visual_tools_->publishText(ee_text_pose, "EE Pose", rviz_visual_tools::WHITE, text_size, text);
-    visual_tools_->publishSphere(ee_pose.translation(), rviz_visual_tools::GREEN, 0.01);
+    ROS_INFO_STREAM_NAMED(name_, "Showing tcp grasp pose");
+    Eigen::Isometry3d tcp_grasp_pose = eef_mount_grasp_pose * grasp_data_->tcp_to_eef_mount_.inverse();
+    visual_tools_->publishAxis(tcp_grasp_pose, 0.05, 0.005);
+    Eigen::Isometry3d tcp_text_pose(tcp_grasp_pose);
+    tcp_text_pose.translation().z() += 0.03;
+    visual_tools_->publishText(tcp_text_pose, "TCP Pose", rviz_visual_tools::WHITE, text_size, text);
+    visual_tools_->publishSphere(tcp_grasp_pose.translation(), rviz_visual_tools::GREEN, 0.01);
     visual_tools_->trigger();
 
     visual_tools_->prompt("Press 'next' to visualize the grasp max and min depth");
 
     // SHOW grasp_max_depth
     ROS_INFO_STREAM_NAMED(name_, "Showing grasp_max_depth");
-    Eigen::Vector3d palm_vector = -ee_pose.translation() + grasp_pose.translation();
+    Eigen::Vector3d palm_vector = -tcp_grasp_pose.translation() + eef_mount_grasp_pose.translation();
     palm_vector.normalize();
     Eigen::Vector3d max_grasp_depth_point =
-        ee_pose.translation() + palm_vector * (grasp_data_->grasp_max_depth_ - grasp_data_->grasp_min_depth_);
-    Eigen::Vector3d min_grasp_depth_point = ee_pose.translation();
+        tcp_grasp_pose.translation() + palm_vector * (grasp_data_->grasp_max_depth_ - grasp_data_->grasp_min_depth_);
+    Eigen::Vector3d min_grasp_depth_point = tcp_grasp_pose.translation();
     visual_tools_->publishLine(min_grasp_depth_point, max_grasp_depth_point, rviz_visual_tools::GREY);
-    Eigen::Isometry3d min_depth_eef_pose = grasp_pose;
+    Eigen::Isometry3d min_depth_eef_pose = eef_mount_grasp_pose;
     visual_tools_->publishEEMarkers(min_depth_eef_pose, ee_jmg, grasp_data_->pre_grasp_posture_.points[0].positions,
                                     rviz_visual_tools::TRANSLUCENT_DARK, "test_eef");
     visual_tools_->trigger();

--- a/src/demo/grasp_poses_visualizer_demo.cpp
+++ b/src/demo/grasp_poses_visualizer_demo.cpp
@@ -138,7 +138,7 @@ public:
 
     // SHOW EE GRASP POSE
     ROS_INFO_STREAM_NAMED(name_, "Showing ee grasp pose");
-    Eigen::Isometry3d ee_pose = grasp_pose * grasp_data_->grasp_pose_to_eef_pose_.inverse();
+    Eigen::Isometry3d ee_pose = grasp_pose * grasp_data_->eef_mount_to_tcp_.inverse();
     visual_tools_->publishAxis(ee_pose, 0.05, 0.005);
     Eigen::Isometry3d ee_text_pose(ee_pose);
     ee_text_pose.translation().z() += 0.03;

--- a/src/grasp_data.cpp
+++ b/src/grasp_data.cpp
@@ -109,7 +109,7 @@ bool GraspData::loadGraspData(const ros::NodeHandle& nh, const std::string& end_
   error += !rosparam_shortcuts::get(parent_name, child_nh, "joints", joint_names);
   error += !rosparam_shortcuts::get(parent_name, child_nh, "pregrasp_posture", pre_grasp_posture);
   error += !rosparam_shortcuts::get(parent_name, child_nh, "grasp_posture", grasp_posture);
-  error += !rosparam_shortcuts::get(parent_name, child_nh, "grasp_pose_to_eef_transform", grasp_pose_to_eef_pose_);
+  error += !rosparam_shortcuts::get(parent_name, child_nh, "eef_mount_to_tcp_transform", eef_mount_to_tcp_);
   error += !rosparam_shortcuts::get(parent_name, child_nh, "grasp_padding_on_approach", grasp_padding_on_approach_);
 
   // Find out if the end effector uses suction or fingers (NOTE: must be one of 'finger' or 'suction')
@@ -327,9 +327,9 @@ bool GraspData::jointPositionsToGraspPosture(std::vector<double> joint_positions
 void GraspData::print()
 {
   ROS_WARN_STREAM_NAMED("grasp_data", "Debug Grasp Data variable values:");
-  std::cout << "grasp_pose_to_eef_pose_: \n"
-            << grasp_pose_to_eef_pose_.translation() << "\n"
-            << grasp_pose_to_eef_pose_.rotation() << std::endl;
+  std::cout << "eef_mount_to_tcp_: \n"
+            << eef_mount_to_tcp_.translation() << "\n"
+            << eef_mount_to_tcp_.rotation() << std::endl;
   std::cout << "pre_grasp_posture_: \n" << pre_grasp_posture_ << std::endl;
   std::cout << "grasp_posture_: \n" << grasp_posture_ << std::endl;
   std::cout << "base_link_: " << base_link_ << std::endl;

--- a/src/grasp_data.cpp
+++ b/src/grasp_data.cpp
@@ -109,7 +109,7 @@ bool GraspData::loadGraspData(const ros::NodeHandle& nh, const std::string& end_
   error += !rosparam_shortcuts::get(parent_name, child_nh, "joints", joint_names);
   error += !rosparam_shortcuts::get(parent_name, child_nh, "pregrasp_posture", pre_grasp_posture);
   error += !rosparam_shortcuts::get(parent_name, child_nh, "grasp_posture", grasp_posture);
-  error += !rosparam_shortcuts::get(parent_name, child_nh, "eef_mount_to_tcp_transform", eef_mount_to_tcp_);
+  error += !rosparam_shortcuts::get(parent_name, child_nh, "tcp_to_eef_mount_transform", tcp_to_eef_mount_);
   error += !rosparam_shortcuts::get(parent_name, child_nh, "grasp_padding_on_approach", grasp_padding_on_approach_);
 
   // Find out if the end effector uses suction or fingers (NOTE: must be one of 'finger' or 'suction')
@@ -327,9 +327,9 @@ bool GraspData::jointPositionsToGraspPosture(std::vector<double> joint_positions
 void GraspData::print()
 {
   ROS_WARN_STREAM_NAMED("grasp_data", "Debug Grasp Data variable values:");
-  std::cout << "eef_mount_to_tcp_: \n"
-            << eef_mount_to_tcp_.translation() << "\n"
-            << eef_mount_to_tcp_.rotation() << std::endl;
+  std::cout << "tcp_to_eef_mount_: \n"
+            << tcp_to_eef_mount_.translation() << "\n"
+            << tcp_to_eef_mount_.rotation() << std::endl;
   std::cout << "pre_grasp_posture_: \n" << pre_grasp_posture_ << std::endl;
   std::cout << "grasp_posture_: \n" << grasp_posture_ << std::endl;
   std::cout << "base_link_: " << base_link_ << std::endl;

--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -223,7 +223,7 @@ bool GraspFilter::filterGraspByOrientation(GraspCandidatePtr grasp_candidate, Ei
 
   // convert grasp pose back to standard grasping orientation
   grasp_pose = visual_tools_->convertPose(grasp_candidate->grasp_.grasp_pose.pose);
-  std_grasp_pose = grasp_pose * grasp_candidate->grasp_data_->grasp_pose_to_eef_pose_.inverse();
+  std_grasp_pose = grasp_pose;  // * grasp_candidate->grasp_data_->eef_mount_to_tcp_.inverse();
 
   // compute the angle between the z-axes of the desired and grasp poses
   grasp_z_axis = std_grasp_pose.rotation() * Eigen::Vector3d(0, 0, 1);
@@ -735,7 +735,7 @@ bool GraspFilter::visualizeCandidateGrasps(const std::vector<GraspCandidatePtr>&
     grasp_candidates[i]->getPreGraspState(robot_state_);
 
     // Show in Rviz
-    visual_tools_->publishRobotState(robot_state_);
+    visual_tools_->publishRobotState(robot_state_, rviz_visual_tools::ORANGE);
     visual_tools_->trigger();
     ros::Duration(show_filtered_arm_solutions_pregrasp_speed_).sleep();
 
@@ -743,7 +743,7 @@ bool GraspFilter::visualizeCandidateGrasps(const std::vector<GraspCandidatePtr>&
     grasp_candidates[i]->getGraspStateClosed(robot_state_);
 
     // Show in Rviz
-    visual_tools_->publishRobotState(robot_state_);
+    visual_tools_->publishRobotState(robot_state_, rviz_visual_tools::WHITE);
     visual_tools_->trigger();
     ros::Duration(show_filtered_arm_solutions_speed_).sleep();
   }

--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -215,18 +215,18 @@ bool GraspFilter::filterGraspByPlane(GraspCandidatePtr grasp_candidate, Eigen::I
 bool GraspFilter::filterGraspByOrientation(GraspCandidatePtr grasp_candidate, Eigen::Isometry3d desired_pose,
                                            double max_angular_offset)
 {
-  Eigen::Isometry3d std_grasp_pose;
-  Eigen::Isometry3d grasp_pose;
+  Eigen::Isometry3d tcp_grasp_pose;
+  Eigen::Isometry3d eef_mount_grasp_pose;
   Eigen::Vector3d desired_z_axis;
   Eigen::Vector3d grasp_z_axis;
   double angle;
 
   // convert grasp pose back to standard grasping orientation
-  grasp_pose = visual_tools_->convertPose(grasp_candidate->grasp_.grasp_pose.pose);
-  std_grasp_pose = grasp_pose;  // * grasp_candidate->grasp_data_->eef_mount_to_tcp_.inverse();
+  eef_mount_grasp_pose = visual_tools_->convertPose(grasp_candidate->grasp_.grasp_pose.pose);
+  tcp_grasp_pose = eef_mount_grasp_pose * grasp_candidate->grasp_data_->tcp_to_eef_mount_.inverse();
 
   // compute the angle between the z-axes of the desired and grasp poses
-  grasp_z_axis = std_grasp_pose.rotation() * Eigen::Vector3d(0, 0, 1);
+  grasp_z_axis = tcp_grasp_pose.rotation() * Eigen::Vector3d(0, 0, 1);
   desired_z_axis = desired_pose.rotation() * Eigen::Vector3d(0, 0, 1);
   angle = acos(grasp_z_axis.normalized().dot(desired_z_axis.normalized()));
 

--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -439,14 +439,6 @@ bool GraspFilter::processCandidateGrasp(IkThreadStructPtr& ik_thread_struct)
   // Get pose
   ik_thread_struct->ik_pose_ = grasp_candidate->grasp_.grasp_pose;
 
-  // Debug
-  if (ik_thread_struct->verbose_ && false)
-  {
-    ik_thread_struct->ik_pose_.header.frame_id = ik_thread_struct->kin_solver_->getBaseFrame();
-    visual_tools_->publishZArrow(ik_thread_struct->ik_pose_.pose, rviz_visual_tools::RED, rviz_visual_tools::MEDIUM,
-                                 0.1);
-  }
-
   // Filter by cutting planes
   for (std::size_t i = 0; i < cutting_planes_.size(); i++)
   {

--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -531,10 +531,10 @@ bool GraspFilter::findIKSolution(std::vector<double>& ik_solution, IkThreadStruc
                                  const moveit::core::GroupStateValidityCallbackFn& constraint_fn)
 {
   // Transform current pose to frame of planning group
-  Eigen::Isometry3d eigen_pose;
-  tf::poseMsgToEigen(ik_thread_struct->ik_pose_.pose, eigen_pose);
-  eigen_pose = ik_thread_struct->link_transform_ * eigen_pose;
-  tf::poseEigenToMsg(eigen_pose, ik_thread_struct->ik_pose_.pose);
+  Eigen::Isometry3d eigen_eef_mount_pose;
+  tf::poseMsgToEigen(ik_thread_struct->ik_pose_.pose, eigen_eef_mount_pose);
+  eigen_eef_mount_pose = ik_thread_struct->link_transform_ * eigen_eef_mount_pose;
+  tf::poseEigenToMsg(eigen_eef_mount_pose, ik_thread_struct->ik_pose_.pose);
 
   // Set callback function
   kinematics::KinematicsBase::IKCallbackFn ik_callback_fn;

--- a/src/grasp_generator.cpp
+++ b/src/grasp_generator.cpp
@@ -108,9 +108,9 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
   Eigen::Vector3d object_size(depth, width, height);
 
   double object_width;
-  std::vector<Eigen::Isometry3d> grasp_poses;
+  std::vector<Eigen::Isometry3d> grasp_poses_tcp;
 
-  Eigen::Isometry3d grasp_pose = cuboid_pose;
+  Eigen::Isometry3d grasp_pose_tcp = cuboid_pose;
   Eigen::Vector3d a_dir, b_dir, c_dir;
 
   if (axis == X_AXIS)
@@ -118,9 +118,9 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
     length_along_a = width;
     length_along_b = height;
     length_along_c = depth;
-    a_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitY();
-    b_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitZ();
-    c_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitX();
+    a_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitY();
+    b_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitZ();
+    c_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitX();
     alpha_x = -M_PI / 2.0;
     alpha_y = 0;
     alpha_z = -M_PI / 2.0;
@@ -131,9 +131,9 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
     length_along_a = depth;
     length_along_b = height;
     length_along_c = width;
-    a_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitX();
-    b_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitZ();
-    c_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitY();
+    a_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitX();
+    b_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitZ();
+    c_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitY();
     alpha_x = 0;
     alpha_y = M_PI / 2.0;
     alpha_z = M_PI;
@@ -144,9 +144,9 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
     length_along_a = depth;
     length_along_b = width;
     length_along_c = height;
-    a_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitX();
-    b_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitY();
-    c_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitZ();
+    a_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitX();
+    b_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitY();
+    c_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitZ();
     alpha_x = M_PI / 2.0;
     alpha_y = M_PI / 2.0;
     alpha_z = 0;
@@ -181,21 +181,21 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
 
     // move to corner 0.5 * ( -a, -b)
     translation = -corner_translation_a - corner_translation_b;
-    addCornerGraspsHelper(cuboid_pose, rotation_angles, translation, 0.0, num_radial_grasps, grasp_poses);
+    addCornerGraspsHelper(cuboid_pose, rotation_angles, translation, 0.0, num_radial_grasps, grasp_poses_tcp);
 
     // move to corner 0.5 * ( -a, +b)
     translation = -corner_translation_a + corner_translation_b;
-    addCornerGraspsHelper(cuboid_pose, rotation_angles, translation, -M_PI / 2.0, num_radial_grasps, grasp_poses);
+    addCornerGraspsHelper(cuboid_pose, rotation_angles, translation, -M_PI / 2.0, num_radial_grasps, grasp_poses_tcp);
 
     // move to corner 0.5 * ( +a, +b)
     translation = corner_translation_a + corner_translation_b;
-    addCornerGraspsHelper(cuboid_pose, rotation_angles, translation, M_PI, num_radial_grasps, grasp_poses);
+    addCornerGraspsHelper(cuboid_pose, rotation_angles, translation, M_PI, num_radial_grasps, grasp_poses_tcp);
 
     // move to corner 0.5 * ( +a, -b)
     translation = corner_translation_a - corner_translation_b;
-    addCornerGraspsHelper(cuboid_pose, rotation_angles, translation, M_PI / 2.0, num_radial_grasps, grasp_poses);
+    addCornerGraspsHelper(cuboid_pose, rotation_angles, translation, M_PI / 2.0, num_radial_grasps, grasp_poses_tcp);
   }
-  std::size_t num_corner_grasps = grasp_poses.size();
+  std::size_t num_corner_grasps = grasp_poses_tcp.size();
 
   // Create grasps along faces of cuboid, grasps are axis aligned
   std::size_t num_grasps_along_a;
@@ -252,43 +252,47 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
     // grasps along -a_dir face
     delta = delta_b * b_dir;
     rotation = 0.0;
-    addFaceGraspsHelper(cuboid_pose, rotation_angles, a_translation, delta, rotation, num_grasps_along_b, grasp_poses);
+    addFaceGraspsHelper(cuboid_pose, rotation_angles, a_translation, delta, rotation, num_grasps_along_b,
+                        grasp_poses_tcp);
 
     // grasps along +b_dir face
     rotation = -M_PI / 2.0;
     delta = -delta_a * a_dir;
-    addFaceGraspsHelper(cuboid_pose, rotation_angles, -b_translation, delta, rotation, num_grasps_along_b, grasp_poses);
+    addFaceGraspsHelper(cuboid_pose, rotation_angles, -b_translation, delta, rotation, num_grasps_along_b,
+                        grasp_poses_tcp);
 
     // grasps along +a_dir face
     rotation = M_PI;
     delta = -delta_b * b_dir;
-    addFaceGraspsHelper(cuboid_pose, rotation_angles, -a_translation, delta, rotation, num_grasps_along_b, grasp_poses);
+    addFaceGraspsHelper(cuboid_pose, rotation_angles, -a_translation, delta, rotation, num_grasps_along_b,
+                        grasp_poses_tcp);
 
     // grasps along -b_dir face
     rotation = M_PI / 2.0;
     delta = delta_a * a_dir;
-    addFaceGraspsHelper(cuboid_pose, rotation_angles, b_translation, delta, rotation, num_grasps_along_b, grasp_poses);
+    addFaceGraspsHelper(cuboid_pose, rotation_angles, b_translation, delta, rotation, num_grasps_along_b,
+                        grasp_poses_tcp);
   }
 
   // add grasps at variable angles
   ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps", "adding variable angle grasps...");
   Eigen::Isometry3d base_pose;
-  std::size_t num_grasps = grasp_poses.size();
+  std::size_t num_grasps = grasp_poses_tcp.size();
   if (grasp_candidate_config.enable_variable_angle_grasps_)
   {
     for (std::size_t i = num_corner_grasps; i < num_grasps;
          i++)  // corner grasps at zero depth don't need variable angles
     {
-      base_pose = grasp_poses[i];
+      base_pose = grasp_poses_tcp[i];
 
-      grasp_pose = base_pose * Eigen::AngleAxisd(angle_res, Eigen::Vector3d::UnitY());
+      grasp_pose_tcp = base_pose * Eigen::AngleAxisd(angle_res, Eigen::Vector3d::UnitY());
       std::size_t max_iterations = M_PI / angle_res + 1;
       std::size_t iterations = 0;
-      while (graspIntersectionHelper(cuboid_pose, depth, width, height, grasp_pose, grasp_data))
+      while (graspIntersectionHelper(cuboid_pose, depth, width, height, grasp_pose_tcp, grasp_data))
       {
-        grasp_poses.push_back(grasp_pose);
-        // visual_tools_->publishZArrow(grasp_pose, rviz_visual_tools::BLUE, rviz_visual_tools::XSMALL, 0.02);
-        grasp_pose *= Eigen::AngleAxisd(angle_res, Eigen::Vector3d::UnitY());
+        grasp_poses_tcp.push_back(grasp_pose_tcp);
+        // visual_tools_->publishZArrow(grasp_pose_tcp, rviz_visual_tools::BLUE, rviz_visual_tools::XSMALL, 0.02);
+        grasp_pose_tcp *= Eigen::AngleAxisd(angle_res, Eigen::Vector3d::UnitY());
         // ros::Duration(0.2).sleep();
         iterations++;
         if (iterations > max_iterations)
@@ -299,12 +303,12 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
       }
 
       iterations = 0;
-      grasp_pose = base_pose * Eigen::AngleAxisd(-angle_res, Eigen::Vector3d::UnitY());
-      while (graspIntersectionHelper(cuboid_pose, depth, width, height, grasp_pose, grasp_data))
+      grasp_pose_tcp = base_pose * Eigen::AngleAxisd(-angle_res, Eigen::Vector3d::UnitY());
+      while (graspIntersectionHelper(cuboid_pose, depth, width, height, grasp_pose_tcp, grasp_data))
       {
-        grasp_poses.push_back(grasp_pose);
-        // visual_tools_->publishZArrow(grasp_pose, rviz_visual_tools::CYAN, rviz_visual_tools::XSMALL, 0.02);
-        grasp_pose *= Eigen::AngleAxisd(-angle_res, Eigen::Vector3d::UnitY());
+        grasp_poses_tcp.push_back(grasp_pose_tcp);
+        // visual_tools_->publishZArrow(grasp_pose_tcp, rviz_visual_tools::CYAN, rviz_visual_tools::XSMALL, 0.02);
+        grasp_pose_tcp *= Eigen::AngleAxisd(-angle_res, Eigen::Vector3d::UnitY());
         // ros::Duration(0.2).sleep();
         iterations++;
         if (iterations > max_iterations)
@@ -348,26 +352,26 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
     // grasps along -a_dir face
     delta = delta_b * b_dir;
     rotation = 0.0;
-    addEdgeGraspsHelper(cuboid_pose, rotation_angles, a_translation, delta, rotation, num_grasps_along_b, grasp_poses,
-                        -M_PI / 4.0 * a_rot_sign);
+    addEdgeGraspsHelper(cuboid_pose, rotation_angles, a_translation, delta, rotation, num_grasps_along_b,
+                        grasp_poses_tcp, -M_PI / 4.0 * a_rot_sign);
 
     // grasps along +b_dir face
     rotation = -M_PI / 2.0;
     delta = -delta_a * a_dir;
-    addEdgeGraspsHelper(cuboid_pose, rotation_angles, -b_translation, delta, rotation, num_grasps_along_b, grasp_poses,
-                        M_PI / 4.0 * b_rot_sign);
+    addEdgeGraspsHelper(cuboid_pose, rotation_angles, -b_translation, delta, rotation, num_grasps_along_b,
+                        grasp_poses_tcp, M_PI / 4.0 * b_rot_sign);
 
     // grasps along +a_dir face
     rotation = M_PI;
     delta = -delta_b * b_dir;
-    addEdgeGraspsHelper(cuboid_pose, rotation_angles, -a_translation, delta, rotation, num_grasps_along_b, grasp_poses,
-                        M_PI / 4.0 * a_rot_sign);
+    addEdgeGraspsHelper(cuboid_pose, rotation_angles, -a_translation, delta, rotation, num_grasps_along_b,
+                        grasp_poses_tcp, M_PI / 4.0 * a_rot_sign);
 
     // grasps along -b_dir face
     rotation = M_PI / 2.0;
     delta = delta_a * a_dir;
-    addEdgeGraspsHelper(cuboid_pose, rotation_angles, b_translation, delta, rotation, num_grasps_along_b, grasp_poses,
-                        -M_PI / 4.0 * b_rot_sign);
+    addEdgeGraspsHelper(cuboid_pose, rotation_angles, b_translation, delta, rotation, num_grasps_along_b,
+                        grasp_poses_tcp, -M_PI / 4.0 * b_rot_sign);
   }
   // Add grasps at variable depths
   ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps", "adding depth grasps...");
@@ -376,34 +380,34 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
     num_depth_grasps = 1;
   delta_f = finger_depth / static_cast<double>(num_depth_grasps);
 
-  num_grasps = grasp_poses.size();
+  num_grasps = grasp_poses_tcp.size();
   Eigen::Vector3d grasp_dir;
   Eigen::Isometry3d depth_pose;
 
   for (std::size_t i = 0; i < num_grasps; i++)
   {
-    grasp_dir = grasp_poses[i].rotation() * Eigen::Vector3d::UnitZ();
-    depth_pose = grasp_poses[i];
+    grasp_dir = grasp_poses_tcp[i].rotation() * Eigen::Vector3d::UnitZ();
+    depth_pose = grasp_poses_tcp[i];
     for (std::size_t j = 0; j < num_depth_grasps; j++)
     {
       depth_pose.translation() += delta_f * grasp_dir;
-      grasp_poses.push_back(depth_pose);
+      grasp_poses_tcp.push_back(depth_pose);
     }
   }
 
   // add grasps in both directions
   ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps", "adding bi-directional grasps...");
-  num_grasps = grasp_poses.size();
+  num_grasps = grasp_poses_tcp.size();
   for (std::size_t i = 0; i < num_grasps; i++)
   {
-    grasp_pose = grasp_poses[i];
-    grasp_pose *= Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitZ());
-    grasp_poses.push_back(grasp_pose);
+    grasp_pose_tcp = grasp_poses_tcp[i];
+    grasp_pose_tcp *= Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitZ());
+    grasp_poses_tcp.push_back(grasp_pose_tcp);
   }
 
   // compute min/max distances to object
   ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps", "computing min/max grasp distance...");
-  num_grasps = grasp_poses.size();
+  num_grasps = grasp_poses_tcp.size();
   min_grasp_distance_ = std::numeric_limits<double>::max();
   max_grasp_distance_ = std::numeric_limits<double>::min();
   min_translations_ = Eigen::Vector3d(std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
@@ -414,8 +418,8 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
 
   for (std::size_t i = 0; i < num_grasps; i++)
   {
-    grasp_pose = grasp_poses[i];
-    grasp_distance = (grasp_pose.translation() - cuboid_pose.translation()).norm();
+    grasp_pose_tcp = grasp_poses_tcp[i];
+    grasp_distance = (grasp_pose_tcp.translation() - cuboid_pose.translation()).norm();
     if (grasp_distance > max_grasp_distance_)
       max_grasp_distance_ = grasp_distance;
 
@@ -424,11 +428,11 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
 
     for (std::size_t j = 0; j < 3; j++)
     {
-      if (grasp_pose.translation()[j] < min_translations_[j])
-        min_translations_[j] = grasp_pose.translation()[j];
+      if (grasp_pose_tcp.translation()[j] < min_translations_[j])
+        min_translations_[j] = grasp_pose_tcp.translation()[j];
 
-      if (grasp_pose.translation()[j] > max_translations_[j])
-        max_translations_[j] = grasp_pose.translation()[j];
+      if (grasp_pose_tcp.translation()[j] > max_translations_[j])
+        max_translations_[j] = grasp_pose_tcp.translation()[j];
     }
   }
 
@@ -438,16 +442,18 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
   // add all poses as possible grasps
   std::size_t num_grasps_added = 0;
 
-  for (std::size_t i = 0; i < grasp_poses.size(); i++)
+  for (std::size_t i = 0; i < grasp_poses_tcp.size(); i++)
   {
-    if (!addGrasp(grasp_poses[i], grasp_data, grasp_candidates, cuboid_pose, object_size, object_width))
+    Eigen::Isometry3d grasp_pose_eef_mount = grasp_poses_tcp[i] * grasp_data->eef_mount_to_tcp_.inverse();
+    if (!addGrasp(grasp_pose_eef_mount, grasp_data, grasp_candidates, cuboid_pose, object_size, object_width))
     {
       ROS_DEBUG_STREAM_NAMED("grasp_generator.add", "Unable to add grasp - function returned false");
     }
     else
       num_grasps_added++;
   }
-  ROS_INFO_STREAM_NAMED("grasp_generator.add", "\033[1;36madded " << num_grasps_added << " of " << grasp_poses.size()
+  ROS_INFO_STREAM_NAMED("grasp_generator.add", "\033[1;36madded " << num_grasps_added << " of "
+                                                                  << grasp_poses_tcp.size()
                                                                   << " grasp poses created\033[0m");
   return true;
 }
@@ -455,64 +461,64 @@ bool GraspGenerator::generateCuboidAxisGrasps(const Eigen::Isometry3d& cuboid_po
 std::size_t GraspGenerator::addFaceGraspsHelper(Eigen::Isometry3d pose, double rotation_angles[3],
                                                 Eigen::Vector3d translation, Eigen::Vector3d delta,
                                                 double alignment_rotation, std::size_t num_grasps,
-                                                std::vector<Eigen::Isometry3d>& grasp_poses)
+                                                std::vector<Eigen::Isometry3d>& grasp_poses_tcp)
 {
   std::size_t num_grasps_added = 0;
   ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper", "delta = \n" << delta);
   ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper", "num_grasps = " << num_grasps);
 
-  Eigen::Isometry3d grasp_pose = pose;
-  grasp_pose *= Eigen::AngleAxisd(rotation_angles[0], Eigen::Vector3d::UnitX()) *
-                Eigen::AngleAxisd(rotation_angles[1], Eigen::Vector3d::UnitY()) *
-                Eigen::AngleAxisd(rotation_angles[2], Eigen::Vector3d::UnitZ());
-  grasp_pose *= Eigen::AngleAxisd(alignment_rotation, Eigen::Vector3d::UnitY());
-  grasp_pose.translation() += translation;
+  Eigen::Isometry3d grasp_pose_tcp = pose;
+  grasp_pose_tcp *= Eigen::AngleAxisd(rotation_angles[0], Eigen::Vector3d::UnitX()) *
+                    Eigen::AngleAxisd(rotation_angles[1], Eigen::Vector3d::UnitY()) *
+                    Eigen::AngleAxisd(rotation_angles[2], Eigen::Vector3d::UnitZ());
+  grasp_pose_tcp *= Eigen::AngleAxisd(alignment_rotation, Eigen::Vector3d::UnitY());
+  grasp_pose_tcp.translation() += translation;
 
   for (std::size_t i = 0; i < num_grasps; i++)
   {
-    grasp_pose.translation() += delta;
-    grasp_poses.push_back(grasp_pose);
+    grasp_pose_tcp.translation() += delta;
+    grasp_poses_tcp.push_back(grasp_pose_tcp);
     num_grasps_added++;
   }
-  ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper",
-                         "num_grasps_added : grasp_poses.size() = " << num_grasps_added << " : " << grasp_poses.size());
+  ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper", "num_grasps_added : grasp_poses_tcp.size() = "
+                                                          << num_grasps_added << " : " << grasp_poses_tcp.size());
   return true;
 }
 
 std::size_t GraspGenerator::addEdgeGraspsHelper(Eigen::Isometry3d pose, double rotation_angles[3],
                                                 Eigen::Vector3d translation, Eigen::Vector3d delta,
                                                 double alignment_rotation, std::size_t num_grasps,
-                                                std::vector<Eigen::Isometry3d>& grasp_poses, double corner_rotation)
+                                                std::vector<Eigen::Isometry3d>& grasp_poses_tcp, double corner_rotation)
 {
   std::size_t num_grasps_added = 0;
   ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper", "delta = \n" << delta);
   ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper", "num_grasps = " << num_grasps);
 
-  Eigen::Isometry3d grasp_pose = pose;
-  grasp_pose *= Eigen::AngleAxisd(rotation_angles[0], Eigen::Vector3d::UnitX()) *
-                Eigen::AngleAxisd(rotation_angles[1], Eigen::Vector3d::UnitY()) *
-                Eigen::AngleAxisd(rotation_angles[2], Eigen::Vector3d::UnitZ());
-  grasp_pose *= Eigen::AngleAxisd(alignment_rotation, Eigen::Vector3d::UnitY());
+  Eigen::Isometry3d grasp_pose_tcp = pose;
+  grasp_pose_tcp *= Eigen::AngleAxisd(rotation_angles[0], Eigen::Vector3d::UnitX()) *
+                    Eigen::AngleAxisd(rotation_angles[1], Eigen::Vector3d::UnitY()) *
+                    Eigen::AngleAxisd(rotation_angles[2], Eigen::Vector3d::UnitZ());
+  grasp_pose_tcp *= Eigen::AngleAxisd(alignment_rotation, Eigen::Vector3d::UnitY());
 
   // rotate towards cuboid
-  grasp_pose *= Eigen::AngleAxisd(corner_rotation, Eigen::Vector3d::UnitX());
-  grasp_pose.translation() += translation;
+  grasp_pose_tcp *= Eigen::AngleAxisd(corner_rotation, Eigen::Vector3d::UnitX());
+  grasp_pose_tcp.translation() += translation;
 
   for (std::size_t i = 0; i < num_grasps; i++)
   {
-    grasp_pose.translation() += delta;
-    grasp_poses.push_back(grasp_pose);
+    grasp_pose_tcp.translation() += delta;
+    grasp_poses_tcp.push_back(grasp_pose_tcp);
     num_grasps_added++;
   }
-  ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper",
-                         "num_grasps_added : grasp_poses.size() = " << num_grasps_added << " : " << grasp_poses.size());
+  ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper", "num_grasps_added : grasp_poses_tcp.size() = "
+                                                          << num_grasps_added << " : " << grasp_poses_tcp.size());
   return true;
 }
 
 std::size_t GraspGenerator::addCornerGraspsHelper(Eigen::Isometry3d pose, double rotation_angles[3],
                                                   Eigen::Vector3d translation, double corner_rotation,
                                                   std::size_t num_radial_grasps,
-                                                  std::vector<Eigen::Isometry3d>& grasp_poses)
+                                                  std::vector<Eigen::Isometry3d>& grasp_poses_tcp)
 {
   std::size_t num_grasps_added = 0;
   double delta_angle = (M_PI / 2.0) / static_cast<double>(num_radial_grasps + 1);
@@ -520,34 +526,35 @@ std::size_t GraspGenerator::addCornerGraspsHelper(Eigen::Isometry3d pose, double
   ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper", "num_radial_grasps = " << num_radial_grasps);
 
   // rotate & translate pose to be aligned with edge of cuboid
-  Eigen::Isometry3d grasp_pose = pose;
-  grasp_pose *= Eigen::AngleAxisd(rotation_angles[0], Eigen::Vector3d::UnitX()) *
-                Eigen::AngleAxisd(rotation_angles[1], Eigen::Vector3d::UnitY()) *
-                Eigen::AngleAxisd(rotation_angles[2], Eigen::Vector3d::UnitZ());
-  grasp_pose *= Eigen::AngleAxisd(corner_rotation, Eigen::Vector3d::UnitY());
-  grasp_pose.translation() += translation;
+  Eigen::Isometry3d grasp_pose_tcp = pose;
+  grasp_pose_tcp *= Eigen::AngleAxisd(rotation_angles[0], Eigen::Vector3d::UnitX()) *
+                    Eigen::AngleAxisd(rotation_angles[1], Eigen::Vector3d::UnitY()) *
+                    Eigen::AngleAxisd(rotation_angles[2], Eigen::Vector3d::UnitZ());
+  grasp_pose_tcp *= Eigen::AngleAxisd(corner_rotation, Eigen::Vector3d::UnitY());
+  grasp_pose_tcp.translation() += translation;
 
   for (std::size_t i = 0; i < num_radial_grasps; i++)
   {
-    // Eigen::Vector3d grasp_dir = grasp_pose.rotation() * Eigen::Vector3d::UnitZ();
-    // Eigen::Isometry3d radial_pose = grasp_pose;
-    grasp_pose *= Eigen::AngleAxisd(delta_angle, Eigen::Vector3d::UnitY());
-    grasp_poses.push_back(grasp_pose);
+    // Eigen::Vector3d grasp_dir = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitZ();
+    // Eigen::Isometry3d radial_pose = grasp_pose_tcp;
+    grasp_pose_tcp *= Eigen::AngleAxisd(delta_angle, Eigen::Vector3d::UnitY());
+    grasp_poses_tcp.push_back(grasp_pose_tcp);
     num_grasps_added++;
   }
-  ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper",
-                         "num_grasps_added : grasp_poses.size() = " << num_grasps_added << " : " << grasp_poses.size());
+  ROS_DEBUG_STREAM_NAMED("cuboid_axis_grasps.helper", "num_grasps_added : grasp_poses_tcp.size() = "
+                                                          << num_grasps_added << " : " << grasp_poses_tcp.size());
   return num_grasps_added;
 }
 
 bool GraspGenerator::graspIntersectionHelper(Eigen::Isometry3d cuboid_pose, double depth, double width, double height,
-                                             Eigen::Isometry3d grasp_pose, const GraspDataPtr grasp_data)
+                                             Eigen::Isometry3d grasp_pose_tcp, const GraspDataPtr grasp_data)
 {
   // TODO(davetcoleman): add parameter to enable vizualization commented lines after further testing
 
   // get line segment from grasp point to fingertip
-  Eigen::Vector3d point_a = grasp_pose.translation();
-  Eigen::Vector3d point_b = point_a + grasp_pose.rotation() * Eigen::Vector3d::UnitZ() * grasp_data->grasp_max_depth_;
+  Eigen::Vector3d point_a = grasp_pose_tcp.translation();
+  Eigen::Vector3d point_b =
+      point_a + grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitZ() * grasp_data->grasp_max_depth_;
 
   // translate points into cuboid coordinate system
   point_a = cuboid_pose.inverse() * point_a;  // T_cuboid-world * p_world = p_cuboid
@@ -666,13 +673,16 @@ bool GraspGenerator::intersectionHelper(double t, double u1, double v1, double u
   return false;
 }
 
-bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr grasp_data,
+bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose_eef_mount, const GraspDataPtr grasp_data,
                               std::vector<GraspCandidatePtr>& grasp_candidates, const Eigen::Isometry3d& object_pose,
                               const Eigen::Vector3d& object_size, double object_width)
 {
+  // Transform the grasp pose eef mount to the tcp grasp pose
+  Eigen::Isometry3d grasp_pose_tcp = grasp_pose_eef_mount * grasp_data->eef_mount_to_tcp_;
+
   if (verbose_)
   {
-    visual_tools_->publishZArrow(grasp_pose, rviz_visual_tools::GREEN, rviz_visual_tools::XXSMALL, 0.05);
+    visual_tools_->publishZArrow(grasp_pose_eef_mount, rviz_visual_tools::GREEN, rviz_visual_tools::XXSMALL, 0.05);
     visual_tools_->trigger();
     ros::Duration(0.01).sleep();
   }
@@ -715,13 +725,7 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDa
   new_grasp.id = "Grasp" + boost::lexical_cast<std::string>(grasp_id);
   grasp_id++;
 
-  // Translate and rotate gripper to match standard orientation
-  // origin on palm, z pointing outward, x perp to gripper close, y parallel to gripper close direction
-  // Transform the grasp pose
-
-  Eigen::Isometry3d eef_pose = grasp_pose * grasp_data->eef_mount_to_tcp_;
-
-  tf::poseEigenToMsg(eef_pose, grasp_pose_msg.pose);
+  tf::poseEigenToMsg(grasp_pose_eef_mount, grasp_pose_msg.pose);
   new_grasp.grasp_pose = grasp_pose_msg;
 
   // set grasp postures e.g. hand closed
@@ -742,7 +746,7 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDa
       return false;
     }
 
-    new_grasp.grasp_quality = scoreFingerGrasp(grasp_pose, grasp_data, object_pose, percent_open);
+    new_grasp.grasp_quality = scoreFingerGrasp(grasp_pose_tcp, grasp_data, object_pose, percent_open);
 
     // Show visualization for widest grasp
 
@@ -756,7 +760,7 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDa
                              grasp_data->grasp_padding_on_approach_);
       return false;
     }
-    new_grasp.grasp_quality = scoreFingerGrasp(grasp_pose, grasp_data, object_pose, percent_open);
+    new_grasp.grasp_quality = scoreFingerGrasp(grasp_pose_tcp, grasp_data, object_pose, percent_open);
     grasp_candidates.push_back(GraspCandidatePtr(new GraspCandidate(new_grasp, grasp_data, object_pose)));
 
     // Create grasp with fingers at minimum width ---------------------------------------------
@@ -767,7 +771,7 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDa
                              grasp_data->grasp_padding_on_approach_);
       return false;
     }
-    new_grasp.grasp_quality = scoreFingerGrasp(grasp_pose, grasp_data, object_pose, percent_open);
+    new_grasp.grasp_quality = scoreFingerGrasp(grasp_pose_tcp, grasp_data, object_pose, percent_open);
     grasp_candidates.push_back(GraspCandidatePtr(new GraspCandidate(new_grasp, grasp_data, object_pose)));
 
     return true;
@@ -775,7 +779,7 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDa
 
   if (grasp_data->end_effector_type_ == SUCTION)
   {
-    new_grasp.grasp_quality = scoreSuctionGrasp(grasp_pose, grasp_data, object_pose, object_size);
+    new_grasp.grasp_quality = scoreSuctionGrasp(grasp_pose_tcp, grasp_data, object_pose, object_size);
     grasp_candidates.push_back(GraspCandidatePtr(new GraspCandidate(new_grasp, grasp_data, object_pose)));
     return true;
   }
@@ -783,15 +787,16 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDa
   return false;
 }
 
-double GraspGenerator::scoreSuctionGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr& grasp_data,
+double GraspGenerator::scoreSuctionGrasp(const Eigen::Isometry3d& grasp_pose_tcp, const GraspDataPtr& grasp_data,
                                          const Eigen::Isometry3d& cuboid_pose, const Eigen::Vector3d& object_size)
 {
   ROS_DEBUG_STREAM_NAMED("grasp_generator.scoreGrasp",
                          "Scoring grasp at: \n\tpose:  ("
-                             << grasp_pose.translation().x() << ",\t" << grasp_pose.translation().y() << ",\t"
-                             << grasp_pose.translation().z() << ")\t(" << grasp_pose.rotation().eulerAngles(0, 1, 2)(0)
-                             << ",\t" << grasp_pose.rotation().eulerAngles(0, 1, 2)(1) << ",\t"
-                             << grasp_pose.rotation().eulerAngles(0, 1, 2)(2) << ")\n\tideal: ("
+                             << grasp_pose_tcp.translation().x() << ",\t" << grasp_pose_tcp.translation().y() << ",\t"
+                             << grasp_pose_tcp.translation().z() << ")\t("
+                             << grasp_pose_tcp.rotation().eulerAngles(0, 1, 2)(0) << ",\t"
+                             << grasp_pose_tcp.rotation().eulerAngles(0, 1, 2)(1) << ",\t"
+                             << grasp_pose_tcp.rotation().eulerAngles(0, 1, 2)(2) << ")\n\tideal: ("
                              << ideal_grasp_pose_.translation().x() << ",\t" << ideal_grasp_pose_.translation().y()
                              << ",\t" << ideal_grasp_pose_.translation().z() << ")\t("
                              << ideal_grasp_pose_.rotation().eulerAngles(0, 1, 2)(0) << ",\t"
@@ -802,17 +807,18 @@ double GraspGenerator::scoreSuctionGrasp(const Eigen::Isometry3d& grasp_pose, co
   Eigen::Isometry3d ideal_grasp = getIdealGraspPose() * grasp_data->eef_mount_to_tcp_.inverse();
   // Move the ideal top grasp to the box location
   ideal_grasp.translation() = cuboid_pose.translation();
-  Eigen::Vector3d orientation_scores = GraspScorer::scoreRotationsFromDesired(grasp_pose, ideal_grasp);
+  Eigen::Vector3d orientation_scores = GraspScorer::scoreRotationsFromDesired(grasp_pose_tcp, ideal_grasp);
 
   // get portion of score based on the translation
-  Eigen::Vector3d translation_scores = GraspScorer::scoreGraspTranslation(grasp_pose, ideal_grasp);
+  Eigen::Vector3d translation_scores = GraspScorer::scoreGraspTranslation(grasp_pose_tcp, ideal_grasp);
 
   // Score suction grasp overhang
   Eigen::Vector2d overhang_score;
   if (show_grasp_overhang_)
-    overhang_score = GraspScorer::scoreGraspOverhang(grasp_pose, grasp_data, cuboid_pose, object_size, visual_tools_);
+    overhang_score =
+        GraspScorer::scoreGraspOverhang(grasp_pose_tcp, grasp_data, cuboid_pose, object_size, visual_tools_);
   else
-    overhang_score = GraspScorer::scoreGraspOverhang(grasp_pose, grasp_data, cuboid_pose, object_size);
+    overhang_score = GraspScorer::scoreGraspOverhang(grasp_pose_tcp, grasp_data, cuboid_pose, object_size);
 
   std::size_t num_scores = 8;
   double weights[num_scores] = {
@@ -852,7 +858,7 @@ double GraspGenerator::scoreSuctionGrasp(const Eigen::Isometry3d& grasp_pose, co
   return total_score;
 }
 
-double GraspGenerator::scoreFingerGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr& grasp_data,
+double GraspGenerator::scoreFingerGrasp(const Eigen::Isometry3d& grasp_pose_tcp, const GraspDataPtr& grasp_data,
                                         const Eigen::Isometry3d& object_pose, double percent_open)
 {
   ROS_DEBUG_STREAM_NAMED("grasp_generator.scoreGrasp", "starting to score grasp...");
@@ -861,7 +867,7 @@ double GraspGenerator::scoreFingerGrasp(const Eigen::Isometry3d& grasp_pose, con
   double width_score = GraspScorer::scoreGraspWidth(grasp_data, percent_open);
 
   // get portion of score based on the pinchers being down
-  Eigen::Vector3d orientation_scores = GraspScorer::scoreRotationsFromDesired(grasp_pose, ideal_grasp_pose_);
+  Eigen::Vector3d orientation_scores = GraspScorer::scoreRotationsFromDesired(grasp_pose_tcp, ideal_grasp_pose_);
 
   // get portion of score based on the distance of the grasp pose to the object pose
 
@@ -869,12 +875,12 @@ double GraspGenerator::scoreFingerGrasp(const Eigen::Isometry3d& grasp_pose, con
   // max_distance should be the length of the fingers minus some minimum amount that the fingers need to grip an object
   // since we don't know the distance from the centoid of the object to the edge of the object, this is set as an
   // arbitrary number given our target object set
-  double distance_score =
-      GraspScorer::scoreDistanceToPalm(grasp_pose, grasp_data, object_pose, min_grasp_distance_, max_grasp_distance_);
+  double distance_score = GraspScorer::scoreDistanceToPalm(grasp_pose_tcp, grasp_data, object_pose, min_grasp_distance_,
+                                                           max_grasp_distance_);
 
   // should really change this to be like orienation_scores so we can score any translation
   Eigen::Vector3d translation_scores =
-      GraspScorer::scoreGraspTranslation(grasp_pose, min_translations_, max_translations_);
+      GraspScorer::scoreGraspTranslation(grasp_pose_tcp, min_translations_, max_translations_);
 
   // want minimum translation
   translation_scores *= -1.0;
@@ -932,7 +938,7 @@ double GraspGenerator::scoreFingerGrasp(const Eigen::Isometry3d& grasp_pose, con
                                << weights[0] << ", " << weights[1] << ", " << weights[2] << ", " << weights[3] << ", "
                                << weights[4] << ", " << weights[5] << ", " << weights[6] << ", " << weights[7] << "\n"
                                << "\ttotal_score         = " << total_score);
-    visual_tools_->publishSphere(grasp_pose.translation(), rviz_visual_tools::PINK, 0.01 * total_score);
+    visual_tools_->publishSphere(grasp_pose_tcp.translation(), rviz_visual_tools::PINK, 0.01 * total_score);
 
     if (false)
     {
@@ -1062,8 +1068,8 @@ bool GraspGenerator::generateSuctionGrasps(const Eigen::Isometry3d& cuboid_top_p
   {
     for (double yaw = yaw_min; yaw < yaw_max; yaw += yaw_increment)
     {
-      Eigen::Isometry3d grasp_pose = grasp_poses_tcp[i] * Eigen::AngleAxisd(yaw, Eigen::Vector3d::UnitZ());
-      grasp_poses_tcp.push_back(grasp_pose);
+      Eigen::Isometry3d grasp_pose_tcp = grasp_poses_tcp[i] * Eigen::AngleAxisd(yaw, Eigen::Vector3d::UnitZ());
+      grasp_poses_tcp.push_back(grasp_pose_tcp);
     }
   }
 
@@ -1073,8 +1079,8 @@ bool GraspGenerator::generateSuctionGrasps(const Eigen::Isometry3d& cuboid_top_p
   {
     for (double z = z_min; z <= z_max; z += z_increment)
     {
-      Eigen::Isometry3d grasp_pose = grasp_poses_tcp[i] * Eigen::Translation3d(0, 0, z);
-      grasp_poses_tcp.push_back(grasp_pose);
+      Eigen::Isometry3d grasp_pose_tcp = grasp_poses_tcp[i] * Eigen::Translation3d(0, 0, z);
+      grasp_poses_tcp.push_back(grasp_pose_tcp);
     }
   }
 
@@ -1084,13 +1090,13 @@ bool GraspGenerator::generateSuctionGrasps(const Eigen::Isometry3d& cuboid_top_p
   {
     for (double y = xy_min; y <= xy_max; y += xy_increment)
     {
-      Eigen::Isometry3d grasp_pose;
+      Eigen::Isometry3d grasp_pose_tcp;
 
-      grasp_pose = grasp_poses_tcp[i] * Eigen::Translation3d(0, y, 0);
-      grasp_poses_tcp.push_back(grasp_pose);
+      grasp_pose_tcp = grasp_poses_tcp[i] * Eigen::Translation3d(0, y, 0);
+      grasp_poses_tcp.push_back(grasp_pose_tcp);
 
-      grasp_pose = grasp_poses_tcp[i] * Eigen::Translation3d(0, -y, 0);
-      grasp_poses_tcp.push_back(grasp_pose);
+      grasp_pose_tcp = grasp_poses_tcp[i] * Eigen::Translation3d(0, -y, 0);
+      grasp_poses_tcp.push_back(grasp_pose_tcp);
     }
   }
 
@@ -1100,13 +1106,13 @@ bool GraspGenerator::generateSuctionGrasps(const Eigen::Isometry3d& cuboid_top_p
   {
     for (double x = xy_min; x <= xy_max; x += xy_increment)
     {
-      Eigen::Isometry3d grasp_pose;
+      Eigen::Isometry3d grasp_pose_tcp;
 
-      grasp_pose = grasp_poses_tcp[i] * Eigen::Translation3d(x, 0, 0);
-      grasp_poses_tcp.push_back(grasp_pose);
+      grasp_pose_tcp = grasp_poses_tcp[i] * Eigen::Translation3d(x, 0, 0);
+      grasp_poses_tcp.push_back(grasp_pose_tcp);
 
-      grasp_pose = grasp_poses_tcp[i] * Eigen::Translation3d(-x, 0, 0);
-      grasp_poses_tcp.push_back(grasp_pose);
+      grasp_pose_tcp = grasp_poses_tcp[i] * Eigen::Translation3d(-x, 0, 0);
+      grasp_poses_tcp.push_back(grasp_pose_tcp);
     }
   }
 
@@ -1212,8 +1218,8 @@ bool GraspGenerator::generateFingerGrasps(const Eigen::Isometry3d& cuboid_pose, 
 Eigen::Vector3d GraspGenerator::getPreGraspDirection(const moveit_msgs::Grasp& grasp, const std::string& ee_parent_link)
 {
   // Grasp Pose Variables
-  Eigen::Isometry3d grasp_pose_eigen;
-  tf::poseMsgToEigen(grasp.grasp_pose.pose, grasp_pose_eigen);
+  Eigen::Isometry3d grasp_pose_eef_mount_eigen;
+  tf::poseMsgToEigen(grasp.grasp_pose.pose, grasp_pose_eef_mount_eigen);
 
   // The direction of the pre-grasp in the frame of the parent link
   Eigen::Vector3d pre_grasp_approach_direction =
@@ -1224,7 +1230,7 @@ Eigen::Vector3d GraspGenerator::getPreGraspDirection(const moveit_msgs::Grasp& g
   if (grasp.pre_grasp_approach.direction.header.frame_id == ee_parent_link)
   {
     // Apply/compute the approach_direction vector in the local frame of the grasp_pose orientation
-    return grasp_pose_eigen.rotation() * pre_grasp_approach_direction;
+    return grasp_pose_eef_mount_eigen.rotation() * pre_grasp_approach_direction;
   }
   return pre_grasp_approach_direction;
 }
@@ -1233,27 +1239,28 @@ geometry_msgs::PoseStamped GraspGenerator::getPreGraspPose(const GraspCandidateP
                                                            const std::string& ee_parent_link)
 {
   // Grasp Pose Variables
-  Eigen::Isometry3d grasp_pose_eigen;
-  tf::poseMsgToEigen(grasp_candidate->grasp_.grasp_pose.pose, grasp_pose_eigen);
+  Eigen::Isometry3d grasp_pose_eef_mount_eigen;
+  tf::poseMsgToEigen(grasp_candidate->grasp_.grasp_pose.pose, grasp_pose_eef_mount_eigen);
 
   // Get pre-grasp pose first
-  Eigen::Isometry3d pre_grasp_pose_eigen = grasp_pose_eigen;  // Copy original grasp pose to pre-grasp pose
+  Eigen::Isometry3d pre_grasp_pose_eef_mount_eigen =
+      grasp_pose_eef_mount_eigen;  // Copy original grasp pose to pre-grasp pose
 
   // Approach direction
   Eigen::Vector3d pre_grasp_approach_direction_local = getPreGraspDirection(grasp_candidate->grasp_, ee_parent_link);
 
   // Update the grasp matrix usign the new locally-framed approach_direction
-  pre_grasp_pose_eigen.translation() -=
+  pre_grasp_pose_eef_mount_eigen.translation() -=
       pre_grasp_approach_direction_local * grasp_candidate->grasp_.pre_grasp_approach.desired_distance;
 
   // Convert eigen pre-grasp position back to regular message
-  geometry_msgs::PoseStamped pre_grasp_pose;
-  tf::poseEigenToMsg(pre_grasp_pose_eigen, pre_grasp_pose.pose);
+  geometry_msgs::PoseStamped pre_grasp_pose_eef_mount_msg;
+  tf::poseEigenToMsg(pre_grasp_pose_eef_mount_eigen, pre_grasp_pose_eef_mount_msg.pose);
 
   // Copy original header to new grasp
-  pre_grasp_pose.header = grasp_candidate->grasp_.grasp_pose.header;
+  pre_grasp_pose_eef_mount_msg.header = grasp_candidate->grasp_.grasp_pose.header;
 
-  return pre_grasp_pose;
+  return pre_grasp_pose_eef_mount_msg;
 }
 
 void GraspGenerator::getGraspWaypoints(const GraspCandidatePtr& grasp_candidate,

--- a/src/grasp_generator.cpp
+++ b/src/grasp_generator.cpp
@@ -560,16 +560,6 @@ bool GraspGenerator::graspIntersectionHelper(Eigen::Isometry3d cuboid_pose, doub
   point_a = cuboid_pose.inverse() * point_a;  // T_cuboid-world * p_world = p_cuboid
   point_b = cuboid_pose.inverse() * point_b;
 
-  // if (verbose_)
-  // {
-  //   visual_tools_->publishCuboid(visual_tools_->convertPose(Eigen::Isometry3d::Identity()), depth, width, height,
-  //   rviz_visual_tools::TRANSLUCENT);
-  //   visual_tools_->publishAxis(Eigen::Isometry3d::Identity());
-  //   visual_tools_->publishSphere(point_a, rviz_visual_tools::WHITE, 0.005);
-  //   visual_tools_->publishSphere(point_b, rviz_visual_tools::GREY, 0.005);
-  //   visual_tools_->publishLine(point_a, point_b, rviz_visual_tools::BLUE, rviz_visual_tools::XSMALL);
-  // }
-
   double t, u, v;
   Eigen::Vector3d intersection;
   // check if line segment intersects XY faces of cuboid (z = +/- height/2)
@@ -680,13 +670,13 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose_eef_mount, con
   // Transform the grasp pose eef mount to the tcp grasp pose
   Eigen::Isometry3d grasp_pose_tcp = grasp_pose_eef_mount * grasp_data->tcp_to_eef_mount_.inverse();
 
-  if (verbose_)
-  {
-    visual_tools_->publishZArrow(grasp_pose_tcp, rviz_visual_tools::GREEN, rviz_visual_tools::XXXSMALL, 0.025);
-    visual_tools_->publishZArrow(grasp_pose_eef_mount, rviz_visual_tools::BLUE, rviz_visual_tools::XXSMALL, 0.05);
-    visual_tools_->trigger();
-    ros::Duration(0.01).sleep();
-  }
+  // if (verbose_)
+  // {
+  //   visual_tools_->publishZArrow(grasp_pose_tcp, rviz_visual_tools::GREEN, rviz_visual_tools::XXXSMALL, 0.025);
+  //   visual_tools_->publishZArrow(grasp_pose_eef_mount, rviz_visual_tools::BLUE, rviz_visual_tools::XXSMALL, 0.05);
+  //   visual_tools_->trigger();
+  //   ros::Duration(0.01).sleep();
+  // }
 
   // The new grasp
   moveit_msgs::Grasp new_grasp;

--- a/src/grasp_generator.cpp
+++ b/src/grasp_generator.cpp
@@ -688,7 +688,7 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDa
   new_grasp.pre_grasp_approach.min_distance = 0;  // NOT IMPLEMENTED
   new_grasp.pre_grasp_approach.direction.header.frame_id = grasp_data->parent_link_->getName();
 
-  Eigen::Vector3d grasp_approach_vector = -1 * grasp_data->grasp_pose_to_eef_pose_.translation();
+  Eigen::Vector3d grasp_approach_vector = -1 * grasp_data->eef_mount_to_tcp_.translation();
   grasp_approach_vector = grasp_approach_vector / grasp_approach_vector.norm();
 
   new_grasp.pre_grasp_approach.direction.vector.x = grasp_approach_vector.x();
@@ -719,7 +719,7 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose, const GraspDa
   // origin on palm, z pointing outward, x perp to gripper close, y parallel to gripper close direction
   // Transform the grasp pose
 
-  Eigen::Isometry3d eef_pose = grasp_pose * grasp_data->grasp_pose_to_eef_pose_;
+  Eigen::Isometry3d eef_pose = grasp_pose * grasp_data->eef_mount_to_tcp_;
 
   tf::poseEigenToMsg(eef_pose, grasp_pose_msg.pose);
   new_grasp.grasp_pose = grasp_pose_msg;

--- a/src/grasp_generator.cpp
+++ b/src/grasp_generator.cpp
@@ -670,14 +670,6 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose_eef_mount, con
   // Transform the grasp pose eef mount to the tcp grasp pose
   Eigen::Isometry3d grasp_pose_tcp = grasp_pose_eef_mount * grasp_data->tcp_to_eef_mount_.inverse();
 
-  // if (verbose_)
-  // {
-  //   visual_tools_->publishZArrow(grasp_pose_tcp, rviz_visual_tools::GREEN, rviz_visual_tools::XXXSMALL, 0.025);
-  //   visual_tools_->publishZArrow(grasp_pose_eef_mount, rviz_visual_tools::BLUE, rviz_visual_tools::XXSMALL, 0.05);
-  //   visual_tools_->trigger();
-  //   ros::Duration(0.01).sleep();
-  // }
-
   // The new grasp
   moveit_msgs::Grasp new_grasp;
 

--- a/src/grasp_generator.cpp
+++ b/src/grasp_generator.cpp
@@ -682,7 +682,8 @@ bool GraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose_eef_mount, con
 
   if (verbose_)
   {
-    visual_tools_->publishZArrow(grasp_pose_eef_mount, rviz_visual_tools::GREEN, rviz_visual_tools::XXSMALL, 0.05);
+    visual_tools_->publishZArrow(grasp_pose_tcp, rviz_visual_tools::GREEN, rviz_visual_tools::XXXSMALL, 0.025);
+    visual_tools_->publishZArrow(grasp_pose_eef_mount, rviz_visual_tools::BLUE, rviz_visual_tools::XXSMALL, 0.05);
     visual_tools_->trigger();
     ros::Duration(0.01).sleep();
   }

--- a/src/grasp_scorer.cpp
+++ b/src/grasp_scorer.cpp
@@ -47,13 +47,13 @@ double GraspScorer::scoreGraspWidth(const GraspDataPtr grasp_data, double percen
   return pow(percent_open, 2);
 }
 
-double GraspScorer::scoreDistanceToPalm(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr grasp_data,
+double GraspScorer::scoreDistanceToPalm(const Eigen::Isometry3d& grasp_pose_tcp, const GraspDataPtr grasp_data,
                                         const Eigen::Isometry3d& object_pose, const double& min_grasp_distance,
                                         const double& max_grasp_distance)
 {
   // TODO(mcevoyandy): grasp_data is not used but should be. See *.h for explaination.
 
-  double distance = (grasp_pose.translation() - object_pose.translation()).norm();
+  double distance = (grasp_pose_tcp.translation() - object_pose.translation()).norm();
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.distance", "distance = " << distance << ", " << min_grasp_distance << ":"
                                                                 << max_grasp_distance);
 
@@ -65,25 +65,25 @@ double GraspScorer::scoreDistanceToPalm(const Eigen::Isometry3d& grasp_pose, con
   return pow(score, 4);
 }
 
-Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Isometry3d& grasp_pose,
+Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Isometry3d& grasp_pose_tcp,
                                                    const Eigen::Isometry3d& ideal_pose)
 {
   // We assume that the ideal is in the middle
-  Eigen::Vector3d scores = -Eigen::Vector3d(grasp_pose.translation() - ideal_pose.translation()).array().abs();
+  Eigen::Vector3d scores = -Eigen::Vector3d(grasp_pose_tcp.translation() - ideal_pose.translation()).array().abs();
 
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.scoreGraspTranslation",
                          "value, ideal, score:\n"
-                             << "x: " << grasp_pose.translation()[0] << "\t" << ideal_pose.translation()[0] << "\t"
+                             << "x: " << grasp_pose_tcp.translation()[0] << "\t" << ideal_pose.translation()[0] << "\t"
                              << scores[0] << "\n"
-                             << "y: " << grasp_pose.translation()[1] << "\t" << ideal_pose.translation()[1] << "\t"
+                             << "y: " << grasp_pose_tcp.translation()[1] << "\t" << ideal_pose.translation()[1] << "\t"
                              << scores[1] << "\n"
-                             << "x: " << grasp_pose.translation()[2] << "\t" << ideal_pose.translation()[2] << "\t"
+                             << "x: " << grasp_pose_tcp.translation()[2] << "\t" << ideal_pose.translation()[2] << "\t"
                              << scores[2] << "\n");
 
   return scores;
 }
 
-Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Isometry3d& grasp_pose,
+Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Isometry3d& grasp_pose_tcp,
                                                    const Eigen::Vector3d& min_translations,
                                                    const Eigen::Vector3d& max_translations)
 {
@@ -93,7 +93,7 @@ Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Isometry3d& gras
   {
     // We assume that the ideal is in the middle
     double ideal = (max_translations[i] + min_translations[i]) / 2;
-    double translation = grasp_pose.translation()[i] - ideal;
+    double translation = grasp_pose_tcp.translation()[i] - ideal;
     double range = max_translations[i] - min_translations[i];
     double score;
     if (range == 0)
@@ -104,18 +104,19 @@ Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Isometry3d& gras
     scores[i] = pow(score, 2);
   }
 
-  ROS_DEBUG_STREAM_NAMED("grasp_scorer.translation", "\nvalue, min, max, score:\n"
-                                                         << grasp_pose.translation()[0] << ", " << min_translations[0]
-                                                         << ", " << max_translations[0] << ", " << scores[0] << "\n"
-                                                         << grasp_pose.translation()[1] << ", " << min_translations[1]
-                                                         << ", " << max_translations[1] << ", " << scores[1] << "\n"
-                                                         << grasp_pose.translation()[2] << ", " << min_translations[2]
-                                                         << ", " << max_translations[2] << ", " << scores[2] << "\n");
+  ROS_DEBUG_STREAM_NAMED("grasp_scorer.translation",
+                         "\nvalue, min, max, score:\n"
+                             << grasp_pose_tcp.translation()[0] << ", " << min_translations[0] << ", "
+                             << max_translations[0] << ", " << scores[0] << "\n"
+                             << grasp_pose_tcp.translation()[1] << ", " << min_translations[1] << ", "
+                             << max_translations[1] << ", " << scores[1] << "\n"
+                             << grasp_pose_tcp.translation()[2] << ", " << min_translations[2] << ", "
+                             << max_translations[2] << ", " << scores[2] << "\n");
 
   return scores;
 }
 
-Eigen::Vector2d GraspScorer::scoreGraspOverhang(const Eigen::Isometry3d& grasp_pose, const GraspDataPtr& grasp_data,
+Eigen::Vector2d GraspScorer::scoreGraspOverhang(const Eigen::Isometry3d& grasp_pose_tcp, const GraspDataPtr& grasp_data,
                                                 const Eigen::Isometry3d& object_pose,
                                                 const Eigen::Vector3d& object_size,
                                                 moveit_visual_tools::MoveItVisualToolsPtr visual_tools)
@@ -132,7 +133,7 @@ Eigen::Vector2d GraspScorer::scoreGraspOverhang(const Eigen::Isometry3d& grasp_p
   Eigen::Vector2d gripper_corner_bl(-grasp_data->active_suction_range_x_ / 2.0,
                                     -grasp_data->active_suction_range_y_ / 2.0);
 
-  Eigen::Isometry3d object_to_gripper_transform = object_pose.inverse() * grasp_pose;
+  Eigen::Isometry3d object_to_gripper_transform = object_pose.inverse() * grasp_pose_tcp;
   Eigen::Affine2d object_to_gripper_transform_2d =
       Eigen::Translation2d(object_to_gripper_transform.translation().topRows<2>()) *
       object_to_gripper_transform.linear().topLeftCorner<2, 2>();
@@ -217,7 +218,7 @@ Eigen::Vector2d GraspScorer::scoreGraspOverhang(const Eigen::Isometry3d& grasp_p
   return scores;
 }
 
-Eigen::Vector3d GraspScorer::scoreRotationsFromDesired(const Eigen::Isometry3d& grasp_pose,
+Eigen::Vector3d GraspScorer::scoreRotationsFromDesired(const Eigen::Isometry3d& grasp_pose_tcp,
                                                        const Eigen::Isometry3d& ideal_pose)
 {
   Eigen::Vector3d grasp_pose_axis;
@@ -226,21 +227,21 @@ Eigen::Vector3d GraspScorer::scoreRotationsFromDesired(const Eigen::Isometry3d& 
   double angle;
 
   // get angle between x-axes
-  grasp_pose_axis = grasp_pose.rotation() * Eigen::Vector3d::UnitX();
+  grasp_pose_axis = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitX();
   ideal_pose_axis = ideal_pose.rotation() * Eigen::Vector3d::UnitX();
   angle = acos(grasp_pose_axis.dot(ideal_pose_axis));
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.angle", "x angle = " << angle * 180.0 / M_PI);
   scores[0] = (M_PI - angle) / M_PI;
 
   // get angle between y-axes
-  grasp_pose_axis = grasp_pose.rotation() * Eigen::Vector3d::UnitY();
+  grasp_pose_axis = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitY();
   ideal_pose_axis = ideal_pose.rotation() * Eigen::Vector3d::UnitY();
   angle = acos(grasp_pose_axis.dot(ideal_pose_axis));
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.angle", "y angle = " << angle * 180.0 / M_PI);
   scores[1] = (M_PI - angle) / M_PI;
 
   // get angle between z-axes
-  grasp_pose_axis = grasp_pose.rotation() * Eigen::Vector3d::UnitZ();
+  grasp_pose_axis = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitZ();
   ideal_pose_axis = ideal_pose.rotation() * Eigen::Vector3d::UnitZ();
   angle = acos(grasp_pose_axis.dot(ideal_pose_axis));
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.angle", "z angle = " << angle * 180.0 / M_PI);

--- a/src/grasp_scorer.cpp
+++ b/src/grasp_scorer.cpp
@@ -181,6 +181,7 @@ Eigen::Vector2d GraspScorer::scoreGraspOverhang(const Eigen::Isometry3d& grasp_p
 
   if (visual_tools)
   {
+    visual_tools->prompt("continue?");
     visual_tools->deleteAllMarkers();
     visual_tools->trigger();
     Eigen::Isometry3d gripper_corner_tr_3d = Eigen::Isometry3d::Identity();

--- a/test/grasp_data_test.cpp
+++ b/test/grasp_data_test.cpp
@@ -71,9 +71,9 @@ protected:
 TEST_F(GraspDataTest, CheckConfigValues)
 {
   // Grasp Pose To EEF Pose
-  EXPECT_EQ(grasp_data_->eef_mount_to_tcp_.translation().x(), 0);
-  EXPECT_EQ(grasp_data_->eef_mount_to_tcp_.translation().y(), 0);
-  EXPECT_EQ(grasp_data_->eef_mount_to_tcp_.translation().z(), -0.105);
+  EXPECT_EQ(grasp_data_->tcp_to_eef_mount_.translation().x(), 0);
+  EXPECT_EQ(grasp_data_->tcp_to_eef_mount_.translation().y(), 0);
+  EXPECT_EQ(grasp_data_->tcp_to_eef_mount_.translation().z(), -0.105);
 
   // Pre Grasp Posture
   EXPECT_EQ(grasp_data_->pre_grasp_posture_.header.frame_id, "world");

--- a/test/grasp_data_test.cpp
+++ b/test/grasp_data_test.cpp
@@ -71,9 +71,9 @@ protected:
 TEST_F(GraspDataTest, CheckConfigValues)
 {
   // Grasp Pose To EEF Pose
-  EXPECT_EQ(grasp_data_->grasp_pose_to_eef_pose_.translation().x(), 0);
-  EXPECT_EQ(grasp_data_->grasp_pose_to_eef_pose_.translation().y(), 0);
-  EXPECT_EQ(grasp_data_->grasp_pose_to_eef_pose_.translation().z(), -0.105);
+  EXPECT_EQ(grasp_data_->eef_mount_to_tcp_.translation().x(), 0);
+  EXPECT_EQ(grasp_data_->eef_mount_to_tcp_.translation().y(), 0);
+  EXPECT_EQ(grasp_data_->eef_mount_to_tcp_.translation().z(), -0.105);
 
   // Pre Grasp Posture
   EXPECT_EQ(grasp_data_->pre_grasp_posture_.header.frame_id, "world");

--- a/test/grasp_filter_test.cpp
+++ b/test/grasp_filter_test.cpp
@@ -99,7 +99,6 @@ TEST_F(GraspFilterTest, TestGraspFilter)
   const double zmax = 0.7;
 
   // Generate grasps for a bunch of random objects
-  EXPECT_TRUE(true);
   const std::size_t num_tests = 5;
   for (std::size_t i = 0; i < num_tests; ++i)
   {

--- a/test/grasp_filter_test.cpp
+++ b/test/grasp_filter_test.cpp
@@ -99,7 +99,8 @@ TEST_F(GraspFilterTest, TestGraspFilter)
   const double zmax = 0.7;
 
   // Generate grasps for a bunch of random objects
-  const std::size_t num_tests = 1;
+  EXPECT_TRUE(true);
+  const std::size_t num_tests = 5;
   for (std::size_t i = 0; i < num_tests; ++i)
   {
     // Generate random cuboid

--- a/test/grasp_filter_test.test
+++ b/test/grasp_filter_test.test
@@ -4,7 +4,7 @@
       <arg name="load_robot_description" value="true"/>
     </include>
 
-    <test pkg="moveit_grasps" type="grasp_filter_test" test-name="grasp_filter_test" time-limit="300" args="">
+    <test pkg="moveit_grasps" type="grasp_filter_test" test-name="grasp_filter_test" time-limit="500" args="">
       <rosparam command="load" file="$(find moveit_grasps)/config_robot/panda_grasp_data.yaml"/>
       <rosparam command="load" file="$(find moveit_grasps)/config/moveit_grasps_config.yaml"/>
     </test>


### PR DESCRIPTION
Replacement for #39 this adds `_tcp` or `_eef_mount` to all `grasp_pose` variables to help disambiguate the code

These changes are reflected in https://github.com/ros-planning/moveit_tutorials/pull/325