### PR TITLE
pre-filter on scores before we run ik

### DIFF
--- a/include/moveit_grasps/grasp_filter.h
+++ b/include/moveit_grasps/grasp_filter.h
@@ -221,12 +221,14 @@ public:
                             const moveit::core::GroupStateValidityCallbackFn& constraint_fn);
 
   /**
-   * \brief  For suction grippers, check that at least one voxel has an overlap > some cutoff.
-   *         This is used as a pre-filter step before IK.
+   * \brief  For suction grippers, check that at least one voxel has an overlap with the grasp target greater than the
+   *         threshold. If not, the grasp_candidate is removed from the vector. This should be used as a pre-filter
+   *          step before IK.
    * \param grasp_candidates - All grasp candidates
-   * \param cutoff - some fractional cutoff where at least one voxel must have > cutoff overlap with the target
+   * \param threshold - some fractional cutoff where at least one voxel must have > threshold overlap with the target
    */
-  void preFilterBySuctionVoxelOverlap(std::vector<moveit_grasps::GraspCandidatePtr>& grasp_candidates, double cutoff);
+  void preFilterBySuctionVoxelOverlap(std::vector<moveit_grasps::GraspCandidatePtr>& grasp_candidates,
+                                      double threshold);
 
   /**
    * \brief add a cutting plane

--- a/include/moveit_grasps/grasp_filter.h
+++ b/include/moveit_grasps/grasp_filter.h
@@ -221,6 +221,14 @@ public:
                             const moveit::core::GroupStateValidityCallbackFn& constraint_fn);
 
   /**
+   * \brief  For suction grippers, check that at least one voxel has an overlap > some cutoff.
+   *         This is used as a pre-filter step before IK.
+   * \param grasp_candidates - All grasp candidates
+   * \param cutoff - some fractional cutoff where at least one voxel must have > cutoff overlap with the target
+   */
+  void preFilterBySuctionVoxelOverlap(std::vector<moveit_grasps::GraspCandidatePtr>& grasp_candidates, double cutoff);
+
+  /**
    * \brief add a cutting plane
    * \param pose - pose describing the cutting plane
    * \param plane - which plane to use as the cutting plane

--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -430,7 +430,7 @@ std::size_t GraspFilter::filterGraspsHelper(std::vector<GraspCandidatePtr>& gras
 }
 
 void GraspFilter::preFilterBySuctionVoxelOverlap(std::vector<moveit_grasps::GraspCandidatePtr>& grasp_candidates,
-                                                 double cutoff)
+                                                 double threshold)
 {
   // We pre-filter by removing all candidates with less than some overlap with the desired object.
   std::size_t grasp_candidates_before = grasp_candidates.size();
@@ -442,11 +442,12 @@ void GraspFilter::preFilterBySuctionVoxelOverlap(std::vector<moveit_grasps::Gras
     bool valid = false;
     for (double& voxel_overlap : grasp_candidates[ix]->suction_voxel_overlap_)
     {
-      ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "cutoff: " << cutoff << "\tvoxel score " << voxel_overlap);
-      if (voxel_overlap > cutoff)
+      ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "threshold: " << threshold << "\tvoxel score "
+                                                                      << voxel_overlap);
+      if (voxel_overlap > threshold)
       {
         valid = true;
-        continue;
+        break;
       }
     }
     if (!valid)

--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -429,6 +429,47 @@ std::size_t GraspFilter::filterGraspsHelper(std::vector<GraspCandidatePtr>& gras
   return remaining_grasps;
 }
 
+void GraspFilter::preFilterBySuctionVoxelOverlap(std::vector<moveit_grasps::GraspCandidatePtr>& grasp_candidates,
+                                                 double cutoff)
+{
+  // We pre-filter by removing all candidates with less than some overlap with the desired object.
+  std::size_t grasp_candidates_before = grasp_candidates.size();
+  std::size_t count = 0;
+  for (std::size_t ix = 0; ix < grasp_candidates.size();)
+  {
+    ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "-------------------------------------------------------");
+    ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "Grasp candidate " << count++);
+    bool valid = false;
+    for (double& voxel_overlap : grasp_candidates[ix]->suction_voxel_overlap_)
+    {
+      ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "cutoff: " << cutoff << "\tvoxel score " << voxel_overlap);
+      if (voxel_overlap > cutoff)
+      {
+        valid = true;
+        continue;
+      }
+    }
+    if (!valid)
+    {
+      ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "Invalid");
+      grasp_candidates.erase(grasp_candidates.begin() + ix);
+    }
+    else
+    {
+      ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "Valid");
+      ++ix;
+    }
+  }
+  if (statistics_verbose_)
+  {
+    ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "-------------------------------------------------------");
+    ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "GRASP PRE-FILTER RESULTS ");
+    ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "total_grasp_candidates:     " << grasp_candidates_before);
+    ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "remaining grasp candidates: " << grasp_candidates.size());
+    ROS_DEBUG_STREAM_NAMED("grasp_filter.pre_filter", "-------------------------------------------------------");
+  }
+}
+
 bool GraspFilter::processCandidateGrasp(IkThreadStructPtr& ik_thread_struct)
 {
   ROS_DEBUG_STREAM_NAMED("grasp_filter.superdebug", "Checking grasp #" << ik_thread_struct->grasp_id);


### PR DESCRIPTION
Pre-filter grasp-candidates for suction voxel overlap before running ik. This is a quick check before we commit to running ik with collision checking