### PR TITLE
set eef mount to tcp transform by link name

### DIFF
--- a/config_robot/panda_grasp_data.yaml
+++ b/config_robot/panda_grasp_data.yaml
@@ -28,11 +28,18 @@ hand:
     # minimum padding on each side of the object on approach
     grasp_padding_on_approach: 0.005  # meter
 
+    # We need to know the transform from the arm IK link to the grasp point. We can set this to a frame in the robot model
+    # by setting `define_tcp_by_name: true` and providing a value for `tcp_name`. If we want to set this directly bt the
+    # transform, We set `define_tcp_by_name: false` and give a value for `tcp_to_eef_mount_transform`.
+    define_tcp_by_name: false
     # Distance from the eef mount to the palm of end effector [x, y, z, r, p, y]
     # z-axis pointing toward object to grasp
     # x-axis perp. to movement of grippers
     # y-axis parallel to movement of grippers
     tcp_to_eef_mount_transform :  [0, 0, -0.105, 0, 0, -0.7853] # NOTE: Imaginary point in the middle
+    # Alternatively, if we have a tool center point frame, we would set:
+    # define_tcp_by_name: true
+    # tcp_link_name: "tool_center_point"
 
     # Joint names and state values for the end effector.
     # The names should match the values of pregrasp_posture and grasp_posture.

--- a/config_robot/panda_grasp_data.yaml
+++ b/config_robot/panda_grasp_data.yaml
@@ -28,10 +28,10 @@ hand:
     # minimum padding on each side of the object on approach
     grasp_padding_on_approach: 0.005  # meter
 
-    # We need to know the transform from the arm IK link to the grasp point. We can set this to a frame in the robot model
-    # by setting `define_tcp_by_name: true` and providing a value for `tcp_name`. If we want to set this directly bt the
-    # transform, We set `define_tcp_by_name: false` and give a value for `tcp_to_eef_mount_transform`.
-    define_tcp_by_name: false
+    # We need to know the transform from the arm IK link to the grasp point. By default we define the transform manually with
+    # `tcp_to_eef_mount_transform`. Alternatively, we can set this to a frame in the robot model and compute the transform
+    # automatically. this is done by setting `define_tcp_by_name: true` and providing a value for `tcp_name`.
+    #
     # Distance from the eef mount to the palm of end effector [x, y, z, r, p, y]
     # z-axis pointing toward object to grasp
     # x-axis perp. to movement of grippers

--- a/include/moveit_grasps/grasp_data.h
+++ b/include/moveit_grasps/grasp_data.h
@@ -254,7 +254,10 @@ public:
   // A representation of the gripper type as an integer. See EndEffectorType for values
   EndEffectorType end_effector_type_;
 
+  // The (possibly fictional) center point of a grasp
+  std::string tcp_name_;
   Eigen::Isometry3d tcp_to_eef_mount_;  // Convert generic grasp pose to the parent arm's eef_mount frame of reference
+
   trajectory_msgs::JointTrajectory pre_grasp_posture_;  // when the end effector is in "open" position
   trajectory_msgs::JointTrajectory grasp_posture_;      // when the end effector is in "close" position
   std::string base_link_;                               // name of global frame with z pointing up

--- a/src/grasp_data.cpp
+++ b/src/grasp_data.cpp
@@ -111,9 +111,9 @@ bool GraspData::loadGraspData(const ros::NodeHandle& nh, const std::string& end_
   error += !rosparam_shortcuts::get(parent_name, child_nh, "grasp_posture", grasp_posture);
   error += !rosparam_shortcuts::get(parent_name, child_nh, "grasp_padding_on_approach", grasp_padding_on_approach_);
 
-  bool use_tcp_name;
-  error += !rosparam_shortcuts::get(parent_name, child_nh, "define_tcp_by_name", use_tcp_name);
-  if (use_tcp_name)
+  bool define_tcp_by_name;
+  child_nh.param<bool>("define_tcp_by_name", define_tcp_by_name, false);
+  if (define_tcp_by_name)
     error += !rosparam_shortcuts::get(parent_name, child_nh, "tcp_name", tcp_name_);
   else
     error += !rosparam_shortcuts::get(parent_name, child_nh, "tcp_to_eef_mount_transform", tcp_to_eef_mount_);
@@ -187,7 +187,7 @@ bool GraspData::loadGraspData(const ros::NodeHandle& nh, const std::string& end_
   ROS_INFO_NAMED("grasp_data", "ee_name: %s, arm_jmg: %s, parent_link: %s", ee_jmg_->getName().c_str(),
                  arm_jmg_->getName().c_str(), parent_link_->getName().c_str());
 
-  if (use_tcp_name)
+  if (define_tcp_by_name)
   {
     robot_state::RobotState state(robot_model_);
     state.setToDefaultValues();


### PR DESCRIPTION
This enables the user to set the tcp_to_eef_mount_ transform by frames rather than explicitly hard-coding a transform