### PR TITLE
fixing suction voxel collision checking filter

### DIFF
--- a/include/moveit_grasps/state_validity_callback.h
+++ b/include/moveit_grasps/state_validity_callback.h
@@ -54,21 +54,19 @@ bool isGraspStateValid(const planning_scene::PlanningScene* planning_scene, bool
                        const double* ik_solution)
 {
   robot_state->setJointGroupPositions(group, ik_solution);
+  robot_state->update();
   if (!robot_state->satisfiesBounds(group))
   {
-    if (visual_debug)
-      ROS_DEBUG_STREAM_NAMED("is_grasp_state_valid", "Ik solution invalid");
-
+    ROS_DEBUG_STREAM_NAMED("is_grasp_state_valid", "Ik solution invalid");
     return false;
   }
-
-  robot_state->update();
 
   if (!planning_scene)
   {
     ROS_ERROR_STREAM_NAMED("is_grasp_state_valid", "No planning scene provided");
     return false;
   }
+
   if (!planning_scene->isStateColliding(*robot_state, group->getName()))
     return true;  // not in collision
 

--- a/src/suction_grasp_candidate.cpp
+++ b/src/suction_grasp_candidate.cpp
@@ -61,7 +61,7 @@ std::vector<bool> SuctionGraspCandidate::getSuctionVoxelEnabled(double suction_v
 {
   std::vector<bool> suction_voxel_enabled(suction_voxel_overlap_.size());
   for (std::size_t voxel_ix = 0; voxel_ix < suction_voxel_enabled.size(); ++voxel_ix)
-    suction_voxel_enabled[voxel_ix] = suction_voxel_overlap_[voxel_ix] > suction_voxel_cutoff;
+    suction_voxel_enabled[voxel_ix] = suction_voxel_overlap_[voxel_ix] >= suction_voxel_cutoff;
   return suction_voxel_enabled;
 }
 

--- a/src/suction_grasp_filter.cpp
+++ b/src/suction_grasp_filter.cpp
@@ -191,7 +191,10 @@ bool SuctionGraspFilter::processCandidateGrasp(const IkThreadStructPtr& ik_threa
   }
 
   if (!filer_results)
+  {
+    ROS_DEBUG_STREAM_NAMED(logger_name, "Candidate grasp invalid");
     return false;
+  }
 
   return true;
 }

--- a/src/suction_grasp_generator.cpp
+++ b/src/suction_grasp_generator.cpp
@@ -339,22 +339,23 @@ bool SuctionGraspGenerator::generateSuctionGrasps(const Eigen::Isometry3d& cuboi
   double yaw_max = 2.0 * M_PI;
 
   // clang-format off
-  if (debug_top_grasps_)
-  {
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "x_min:                  " << x_min);
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "x_max:                  " << x_max);
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "depth:                  " << depth);
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "active_suction_range_x: " << grasp_data->suction_voxel_matrix_->getActiveSuctionWidthX());
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "voxel_x_width:          " << grasp_data->suction_voxel_matrix_->getVoxelWidthX());
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "y_min:                  " << y_min);
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "y_max:                  " << y_max);
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "width:                  " << width);
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "active_suction_range_y: " << grasp_data->suction_voxel_matrix_->getActiveSuctionWidthY());
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "voxel_y_width:          " << grasp_data->suction_voxel_matrix_->getVoxelWidthY());
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "z_min:                  " << z_min);
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "z_max:                  " << z_max);
-    ROS_DEBUG_STREAM_NAMED("grasp_generator.suction", "xy_increment:           " << xy_increment);
-  }
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "x_min:                  " << x_min);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "x_max:                  " << x_max);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "depth:                  " << depth);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "active_suction_range_x: " << grasp_data->suction_voxel_matrix_->getActiveSuctionWidthX());
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "voxel_x_width:          " << grasp_data->suction_voxel_matrix_->getVoxelWidthX());
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "y_min:                  " << y_min);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "y_max:                  " << y_max);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "width:                  " << width);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "active_suction_range_y: " << grasp_data->suction_voxel_matrix_->getActiveSuctionWidthY());
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "voxel_y_width:          " << grasp_data->suction_voxel_matrix_->getVoxelWidthY());
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "z_min:                  " << z_min);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "z_max:                  " << z_max);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "xy_increment:           " << xy_increment);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "yaw_increment:          " << yaw_increment);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "yaw_min:                " << yaw_min);
+  ROS_DEBUG_STREAM_NAMED("grasp_generator.suction.range", "yaw_max:                " << yaw_max);
+
   // clang-format on
 
   // For each range (X, Y, Z, Yaw) create copies of the grasp poses for each value in the range

--- a/test/two_finger_grasp_filter_test.cpp
+++ b/test/two_finger_grasp_filter_test.cpp
@@ -155,7 +155,9 @@ TEST_F(GraspFilterTest, TestGraspFilter)
                             "issue";
 
     remaining_grasps = grasp_filter_->removeInvalidAndFilter(grasp_candidates);
-    EXPECT_NE(remaining_grasps, 0) << "No valid grasps remain after filtering with collision object and ACM settings";
+    std::size_t expected_remaining_grasps = 0;
+    EXPECT_NE(remaining_grasps, expected_remaining_grasps) << "No valid grasps remain after filtering with collision "
+                                                              "object and ACM settings";
 
     success = grasp_filter_->filterGrasps(grasp_candidates, visual_tools_->getPlanningSceneMonitor(), arm_jmg_,
                                           visual_tools_->getSharedRobotState(), filter_pregrasps);
@@ -163,7 +165,9 @@ TEST_F(GraspFilterTest, TestGraspFilter)
                             "issue";
 
     remaining_grasps = grasp_filter_->removeInvalidAndFilter(grasp_candidates);
-    EXPECT_EQ(remaining_grasps, 0) << "Valid grasps found after IK filtering despite collisions";
+    expected_remaining_grasps = 0;
+    EXPECT_EQ(remaining_grasps, expected_remaining_grasps) << "Valid grasps found after IK filtering despite "
+                                                              "collisions";
   }
 }
 


### PR DESCRIPTION
Changes how the GraspFilter does IK to filter grasps to use the constraint function method rather than the IK function adapter method. Also updates the ACM so that collisions between suction voxels and the eef are not considered. 