### PR TITLE
Change error when all grasps filtered to warning

### DIFF
--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -641,7 +641,7 @@ bool GraspFilter::removeInvalidAndFilter(std::vector<GraspCandidatePtr>& grasp_c
   // Error Check
   if (grasp_candidates.empty())
   {
-    ROS_ERROR_STREAM_NAMED(name_, "No remaining grasp candidates");
+    ROS_WARN_STREAM_NAMED(name_, "No remaining grasp candidates");
     return false;
   }
 


### PR DESCRIPTION
All grasps being filtered is not really a true error, as it can easily happen under normal operation due to an object being difficult to pick up, and does not necessarily mean that something has gone wrong.