### PR TITLE
Remove reference to nonexistant getEmptyPose()

### DIFF
--- a/src/demo/grasp_generator_demo.cpp
+++ b/src/demo/grasp_generator_demo.cpp
@@ -164,10 +164,7 @@ public:
     // Animate open and closing end effector
     if (true)
     {
-      // TODO(davetcoleman): after next release of rviz_visual_tools:
-      // geometry_msgs::Pose pose = visual_tools_->getIdentityPose();
-      geometry_msgs::Pose pose;
-      visual_tools_->generateEmptyPose(pose);
+      geometry_msgs::Pose pose = visual_tools_->getIdentityPose();
       pose.position.x = .3;
 
       // Test visualization of end effector in OPEN position


### PR DESCRIPTION
PickNikRobotics/rviz_visual_tools@cc4ee1e642d94bdb120b51d19585bb274dcc96b0 removed a function used by grasp_generator_demo.  This replaces the use of that function with the newer getIdentityPose function.