### PR TITLE
Fix some dangerous acos and cleanup

### DIFF
--- a/include/moveit_grasps/grasp_planner.h
+++ b/include/moveit_grasps/grasp_planner.h
@@ -149,7 +149,7 @@ private:
   WaitForNextStepCallback wait_for_next_step_callback_;
 
   // Visualization settings
-  bool enabled_setttings_loaded_ = false;
+  bool enabled_settings_loaded_ = false;
   std::map<std::string, bool> enabled_setting_;
 
 };  // end class

--- a/include/moveit_grasps/suction_grasp_generator.h
+++ b/include/moveit_grasps/suction_grasp_generator.h
@@ -82,13 +82,20 @@ public:
    * \param grasp_data data describing the end effector
    * \param object_pose - pose of object to grasp
    * \param object_size - size of object to grasp
-   * \param object_width - In the case of finger grippers, the width of the object in the dimension betwen the fingers
    * \param grasp_candidates - output, list possible grasps with new grasp appended
    * \return true on success
    */
   bool addGrasp(const Eigen::Isometry3d& grasp_pose_eef_mount, const SuctionGraspDataPtr& grasp_data,
-                const Eigen::Isometry3d& object_pose, const Eigen::Vector3d& object_size, double object_width,
+                const Eigen::Isometry3d& object_pose, const Eigen::Vector3d& object_size,
                 std::vector<GraspCandidatePtr>& grasp_candidates);
+
+  [[deprecated("Object_width no longer needs to be specified for suction grasps")]] bool
+  addGrasp(const Eigen::Isometry3d& grasp_pose_eef_mount, const SuctionGraspDataPtr& grasp_data,
+           const Eigen::Isometry3d& object_pose, const Eigen::Vector3d& object_size, double object_width,
+           std::vector<GraspCandidatePtr>& grasp_candidates)
+  {
+    return addGrasp(grasp_pose_eef_mount, grasp_data, object_pose, object_size, grasp_candidates);
+  }
 
   /**
    * \brief Setter for grasp score weights

--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -230,7 +230,8 @@ bool GraspFilter::filterGraspByOrientation(GraspCandidatePtr& grasp_candidate, c
   // compute the angle between the z-axes of the desired and grasp poses
   grasp_z_axis = tcp_grasp_pose.rotation() * Eigen::Vector3d(0, 0, 1);
   desired_z_axis = desired_pose.rotation() * Eigen::Vector3d(0, 0, 1);
-  angle = acos(grasp_z_axis.normalized().dot(desired_z_axis.normalized()));
+  double cos_angle = grasp_z_axis.normalized().dot(desired_z_axis.normalized());
+  angle = acos(std::max(-1.0, std::min(1.0, cos_angle)));
 
   if (angle > max_angular_offset)
   {

--- a/src/grasp_planner.cpp
+++ b/src/grasp_planner.cpp
@@ -405,9 +405,9 @@ void GraspPlanner::setWaitForNextStepCallback(WaitForNextStepCallback callback)
 bool GraspPlanner::loadEnabledSettings()
 {
   // Check if the map has been loaded yet
-  if (!enabled_setttings_loaded_)
+  if (!enabled_settings_loaded_)
   {
-    enabled_setttings_loaded_ = true;
+    enabled_settings_loaded_ = true;
     return rosparam_shortcuts::get(ENABLED_PARENT_NAME, nh_, ENABLED_SETTINGS_NAMESPACE, enabled_setting_);
   }
   return true;
@@ -416,7 +416,7 @@ bool GraspPlanner::loadEnabledSettings()
 bool GraspPlanner::isEnabled(const std::string& setting_name)
 {
   // Check if the map has been loaded yet. it is preferred if this is called manually
-  if (!enabled_setttings_loaded_)
+  if (!enabled_settings_loaded_)
     ROS_ERROR_STREAM_NAMED("rosparam_shortcuts", "Enabled settings are not yet loaded e.g. call loadEnabledSettings()");
 
   std::map<std::string, bool>::iterator it = enabled_setting_.find(setting_name);

--- a/src/grasp_scorer.cpp
+++ b/src/grasp_scorer.cpp
@@ -81,26 +81,30 @@ Eigen::Vector3d GraspScorer::scoreRotationsFromDesired(const Eigen::Isometry3d& 
   Eigen::Vector3d grasp_pose_axis;
   Eigen::Vector3d ideal_pose_axis;
   Eigen::Vector3d scores;
+  double cos_angle;
   double angle;
 
   // get angle between x-axes
   grasp_pose_axis = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitX();
   ideal_pose_axis = ideal_pose.rotation() * Eigen::Vector3d::UnitX();
-  angle = acos(grasp_pose_axis.dot(ideal_pose_axis));
+  cos_angle = grasp_pose_axis.dot(ideal_pose_axis);
+  angle = acos(std::max(-1.0, std::min(1.0, cos_angle)));
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.angle", "x angle = " << angle * 180.0 / M_PI);
   scores[0] = (M_PI - angle) / M_PI;
 
   // get angle between y-axes
   grasp_pose_axis = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitY();
   ideal_pose_axis = ideal_pose.rotation() * Eigen::Vector3d::UnitY();
-  angle = acos(grasp_pose_axis.dot(ideal_pose_axis));
+  cos_angle = grasp_pose_axis.dot(ideal_pose_axis);
+  angle = acos(std::max(-1.0, std::min(1.0, cos_angle)));
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.angle", "y angle = " << angle * 180.0 / M_PI);
   scores[1] = (M_PI - angle) / M_PI;
 
   // get angle between z-axes
   grasp_pose_axis = grasp_pose_tcp.rotation() * Eigen::Vector3d::UnitZ();
   ideal_pose_axis = ideal_pose.rotation() * Eigen::Vector3d::UnitZ();
-  angle = acos(grasp_pose_axis.dot(ideal_pose_axis));
+  cos_angle = grasp_pose_axis.dot(ideal_pose_axis);
+  angle = acos(std::max(-1.0, std::min(1.0, cos_angle)));
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.angle", "z angle = " << angle * 180.0 / M_PI);
   scores[2] = (M_PI - angle) / M_PI;
 

--- a/src/suction_grasp_filter.cpp
+++ b/src/suction_grasp_filter.cpp
@@ -174,7 +174,7 @@ bool SuctionGraspFilter::processCandidateGrasp(const IkThreadStructPtr& ik_threa
                       ik_thread_struct->planning_scene_);
   }
 
-  bool filer_results = GraspFilter::processCandidateGrasp(ik_thread_struct);
+  bool filter_results = GraspFilter::processCandidateGrasp(ik_thread_struct);
 
   // Cleanup ACM changes
   if (!ik_thread_struct->grasp_target_object_id_.empty() && !collision_object_names.empty())
@@ -190,7 +190,7 @@ bool SuctionGraspFilter::processCandidateGrasp(const IkThreadStructPtr& ik_threa
     return false;
   }
 
-  if (!filer_results)
+  if (!filter_results)
   {
     ROS_DEBUG_STREAM_NAMED(logger_name, "Candidate grasp invalid");
     return false;

--- a/src/suction_grasp_generator.cpp
+++ b/src/suction_grasp_generator.cpp
@@ -42,20 +42,6 @@
 
 #include <rosparam_shortcuts/rosparam_shortcuts.h>
 
-namespace
-{
-void debugFailedOpenGripper(double percent_open, double min_finger_open_on_approach, double object_width,
-                            double grasp_padding_on_approach)
-{
-  ROS_ERROR_STREAM_NAMED("grasp_generator", "Unable to set grasp width to "
-                                                << percent_open << " % open. Stats:"
-                                                << "\n min_finger_open_on_approach: \t " << min_finger_open_on_approach
-                                                << "\n object_width: \t " << object_width
-                                                << "\n grasp_padding_on_approach_: \t " << grasp_padding_on_approach);
-}
-
-}  // namespace
-
 namespace moveit_grasps
 {
 // Constructor
@@ -79,7 +65,7 @@ SuctionGraspGenerator::SuctionGraspGenerator(const moveit_visual_tools::MoveItVi
 
 bool SuctionGraspGenerator::addGrasp(const Eigen::Isometry3d& grasp_pose_eef_mount,
                                      const SuctionGraspDataPtr& grasp_data, const Eigen::Isometry3d& object_pose,
-                                     const Eigen::Vector3d& object_size, double object_width,
+                                     const Eigen::Vector3d& object_size,
                                      std::vector<GraspCandidatePtr>& grasp_candidates)
 {
   // Transform the grasp pose eef mount to the tcp grasp pose
@@ -413,7 +399,7 @@ bool SuctionGraspGenerator::generateSuctionGrasps(const Eigen::Isometry3d& cuboi
   for (std::size_t i = 0; i < num_grasps; ++i)
   {
     Eigen::Isometry3d grasp_pose_eef_mount = grasp_poses_tcp[i] * grasp_data->tcp_to_eef_mount_;
-    addGrasp(grasp_pose_eef_mount, grasp_data, cuboid_top_pose, object_size, 0, grasp_candidates);
+    addGrasp(grasp_pose_eef_mount, grasp_data, cuboid_top_pose, object_size, grasp_candidates);
     if (debug_top_grasps_)
     {
       visual_tools_->publishAxis(grasp_poses_tcp[i], rviz_visual_tools::MEDIUM, "tcp pose");

--- a/src/suction_grasp_scorer.cpp
+++ b/src/suction_grasp_scorer.cpp
@@ -61,7 +61,7 @@ double SuctionGraspScoreWeights::computeScore(const Eigen::Vector3d& orientation
   {
     static const std::string logger_name = "grasp_scorer.compute_score";
     // clang-format off
-    ROS_DEBUG_STREAM_NAMED(logger_name, "Two Finger Grasp score: ");
+    ROS_DEBUG_STREAM_NAMED(logger_name, "Suction Grasp score: ");
     ROS_DEBUG_STREAM_NAMED(logger_name, "\torientation_score.x = " << orientation_scores[0] << "\tweight = "<< orientation_x_score_weight_);
     ROS_DEBUG_STREAM_NAMED(logger_name, "\torientation_score.y = " << orientation_scores[1] << "\tweight = "<< orientation_y_score_weight_);
     ROS_DEBUG_STREAM_NAMED(logger_name, "\torientation_score.z = " << orientation_scores[2] << "\tweight = "<< orientation_z_score_weight_);


### PR DESCRIPTION
This PR does a couple things but is split into distinct (small) commits.

 - Fix a few typos
 - Remove from suction grasp files a bit of code that is only relevant for two finger grasps
 - When calling `acos` on the result of a dot product, clip the argument to make sure it is not slightly out of the required domain `[-1, 1]` due to floating point errors.