### PR TITLE
(WIP) Disable individual suction voxels from collision

### DIFF
--- a/include/moveit_grasps/suction_grasp_candidate.h
+++ b/include/moveit_grasps/suction_grasp_candidate.h
@@ -65,15 +65,22 @@ public:
 
   void setSuctionVoxelOverlap(std::vector<double> suction_voxel_overlap);
 
+  void setSuctionVoxelInCollision(std::vector<bool> voxel_in_collision);
+
   std::vector<double> getSuctionVoxelOverlap();
 
   std::vector<bool> getSuctionVoxelEnabled(double cutoff);
+
+  std::vector<bool> getSuctionVoxelInCollision();
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 protected:
   // A vector of fractions maped to suction gripper voxels. [0,1] representing the fraction of the
   // suction voxel that overlaps the object
   std::vector<double> suction_voxel_overlap_;
+  // Whether the voxel is colliding with any objects other than the target.
+  // If it is, then using the voxel risks attaching to other unintended objects
+  std::vector<bool> voxel_in_collision_;
 
 };  // class
 

--- a/include/moveit_grasps/suction_grasp_filter.h
+++ b/include/moveit_grasps/suction_grasp_filter.h
@@ -109,15 +109,15 @@ protected:
                              const planning_scene::PlanningScenePtr& planning_scene);
 
   /**
-   * \brief  Add a collision object in the location of every active suction voxel. This is used for collision
+   * \brief  Add a collision object in the location of active suction voxel. This is used for collision
    *         checking between the suction cups and other objects in the scene that you do not want to pick up
    * \param grasp_data - A pointer to a SuctionGraspData with a populated SuctionVoxelMatrix
    * \param planning_scene - A pointer to a planning scene where we will attach the collision objects
    * \param collision_object_names - Output, the collision object names added to the planning scene
    */
-  bool attachActiveSuctionCupCO(const SuctionGraspDataPtr& grasp_data, const std::vector<bool>& suction_voxel_enabled,
-                                const planning_scene::PlanningScenePtr& planning_scene,
-                                std::vector<std::string>& collision_object_names);
+  bool attachAllSuctionCupCO(const SuctionGraspDataPtr& grasp_data,
+                             const planning_scene::PlanningScenePtr& planning_scene,
+                             std::vector<std::string>& collision_object_names);
 
   /* \brief a method for transforming from voxel index to voxel collision object ID used by attachActiveSuctionCupCO and
    * removeAllSuctionCupCO */

--- a/src/suction_grasp_candidate.cpp
+++ b/src/suction_grasp_candidate.cpp
@@ -44,6 +44,7 @@ SuctionGraspCandidate::SuctionGraspCandidate(const moveit_msgs::Grasp& grasp, co
                                              const Eigen::Isometry3d& cuboid_pose)
   : GraspCandidate::GraspCandidate(grasp, std::dynamic_pointer_cast<GraspData>(grasp_data), cuboid_pose)
   , suction_voxel_overlap_(grasp_data->suction_voxel_matrix_->getNumVoxels())
+  , voxel_in_collision_(grasp_data->suction_voxel_matrix_->getNumVoxels())
 {
 }
 
@@ -57,11 +58,24 @@ std::vector<double> SuctionGraspCandidate::getSuctionVoxelOverlap()
   return suction_voxel_overlap_;
 }
 
+void SuctionGraspCandidate::setSuctionVoxelInCollision(std::vector<bool> voxel_in_collision)
+{
+  voxel_in_collision_ = voxel_in_collision;
+}
+
+std::vector<bool> SuctionGraspCandidate::getSuctionVoxelInCollision()
+{
+  return voxel_in_collision_;
+}
+
 std::vector<bool> SuctionGraspCandidate::getSuctionVoxelEnabled(double suction_voxel_cutoff)
 {
   std::vector<bool> suction_voxel_enabled(suction_voxel_overlap_.size());
   for (std::size_t voxel_ix = 0; voxel_ix < suction_voxel_enabled.size(); ++voxel_ix)
-    suction_voxel_enabled[voxel_ix] = suction_voxel_overlap_[voxel_ix] >= suction_voxel_cutoff;
+  {
+    suction_voxel_enabled[voxel_ix] =
+        (suction_voxel_overlap_[voxel_ix] >= suction_voxel_cutoff && !voxel_in_collision_[voxel_ix]);
+  }
   return suction_voxel_enabled;
 }
 

--- a/test/suction_grasp_unit_tests.cpp
+++ b/test/suction_grasp_unit_tests.cpp
@@ -351,7 +351,7 @@ TEST_F(SuctionGraspUnitTests, TestFilterSuctionIKHighOverlap)
 
 // Ensure that we do not filter all grasps when trying to pick up an object larger than a suction voxel and surrounded
 // on all sides
-TEST_F(SuctionGraspUnitTests, DISABLED_TestFilterSuctionIKLowOverlap)
+TEST_F(SuctionGraspUnitTests, TestFilterSuctionIKLowOverlap)
 {
   // This test is identical to TestFilterSuctionIKHighOverlap except with a lower overlap cutoff
   // -----------------------------------


### PR DESCRIPTION
Opening this for feedback on the general strategy as described in this summary, especially the changes to `SuctionGraspFilter`, as the rest of the code still includes several temporary changes used for testing and needs a bit of extra fixing.  Includes #86, so only the last commit is new. 

This offers a solution to the problem shown in the `TestFilterSuctionIKLowOverlap` test, where setting a low overlap threshold can unexpectedly cause all grasps to be filtered due to collision checking with suction voxels.  Instead of throwing out the entire candidate grasp when a collision with a suction voxel is detected, this PR takes the strategy of:

1) First process the grasp normally without the suction voxels attached, including IK checking
2) Attach all suction voxels
3) Generate an `AllowedCollisionMatrix` such that we can check collisions only between the suction voxels and objects other than the target box
4) Perform collision checking, and disable any suction voxel that is in collision
5) The grasp candidate is thrown out if all suction voxels have been disabled in this way
6) Here, we could potentially filter by overall overlap (rather than individual voxel overlap) based on which voxels are still enabled.

This PR still needs work with regard to combining with the suction overlap cutoff filter in a clean way, perhaps reverting to prefiltering and only attaching active voxels.  Currently it requires filtering by suction overlap second. 