### PR TITLE
Fix breaking changes of RobotState::attachBody

### DIFF
--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -592,7 +592,7 @@ bool GraspFilter::findIKSolution(std::vector<double>& ik_solution, const IkThrea
   ik_thread_struct->planning_scene_->getCurrentState().getAttachedBodies(attached_bodies);
 
   for (const robot_state::AttachedBody* ab : attached_bodies)
-    state.attachBody(ab->getName(), ab->getShapes(), ab->getFixedTransforms(), ab->getTouchLinks(),
+    state.attachBody(ab->getName(), ab->getShapes(), ab->getShapePoses(), ab->getTouchLinks(),
                      ab->getAttachedLinkName(), ab->getDetachPosture());
 
   bool ik_success = state.setFromIK(grasp_candidate->grasp_data_->arm_jmg_, ik_thread_struct->ik_pose_.pose,

--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -592,9 +592,8 @@ bool GraspFilter::findIKSolution(std::vector<double>& ik_solution, const IkThrea
   ik_thread_struct->planning_scene_->getCurrentState().getAttachedBodies(attached_bodies);
 
   for (const robot_state::AttachedBody* ab : attached_bodies)
-    state.attachBody(ab->getName(), ab->getPose(), ab->getShapes(), ab->getShapePoses(), 
-                     ab->getTouchLinks(), ab->getAttachedLinkName(), ab->getDetachPosture(),
-                     ab->getSubframes());
+    state.attachBody(ab->getName(), ab->getPose(), ab->getShapes(), ab->getShapePoses(), ab->getTouchLinks(),
+                     ab->getAttachedLinkName(), ab->getDetachPosture(), ab->getSubframes());
 
   bool ik_success = state.setFromIK(grasp_candidate->grasp_data_->arm_jmg_, ik_thread_struct->ik_pose_.pose,
                                     ik_thread_struct->timeout_, constraint_fn);

--- a/src/grasp_filter.cpp
+++ b/src/grasp_filter.cpp
@@ -592,8 +592,9 @@ bool GraspFilter::findIKSolution(std::vector<double>& ik_solution, const IkThrea
   ik_thread_struct->planning_scene_->getCurrentState().getAttachedBodies(attached_bodies);
 
   for (const robot_state::AttachedBody* ab : attached_bodies)
-    state.attachBody(ab->getName(), ab->getShapes(), ab->getShapePoses(), ab->getTouchLinks(),
-                     ab->getAttachedLinkName(), ab->getDetachPosture());
+    state.attachBody(ab->getName(), ab->getPose(), ab->getShapes(), ab->getShapePoses(), 
+                     ab->getTouchLinks(), ab->getAttachedLinkName(), ab->getDetachPosture(),
+                     ab->getSubframes());
 
   bool ik_success = state.setFromIK(grasp_candidate->grasp_data_->arm_jmg_, ik_thread_struct->ik_pose_.pose,
                                     ik_thread_struct->timeout_, constraint_fn);

--- a/src/grasp_planner.cpp
+++ b/src/grasp_planner.cpp
@@ -346,8 +346,8 @@ bool GraspPlanner::computeCartesianWaypointPath(GraspCandidatePtr& grasp_candida
         std::vector<const robot_state::AttachedBody*> attached_bodies;
         start_state_with_body->getAttachedBodies(attached_bodies);
         for (const auto& ab : attached_bodies)
-          start_state_copy->attachBody(ab->getName(), ab->getPose(), ab->getShapes(), ab->getShapePoses(), 
-                                       ab->getTouchLinks(), ab->getAttachedLinkName(), ab->getDetachPosture(), 
+          start_state_copy->attachBody(ab->getName(), ab->getPose(), ab->getShapes(), ab->getShapePoses(),
+                                       ab->getTouchLinks(), ab->getAttachedLinkName(), ab->getDetachPosture(),
                                        ab->getSubframes());
         constraint_fn = boost::bind(&isGraspStateValid, scene.get(), collision_checking_verbose,
                                     only_check_self_collision, visual_tools_, _1, _2, _3);

--- a/src/grasp_planner.cpp
+++ b/src/grasp_planner.cpp
@@ -346,7 +346,7 @@ bool GraspPlanner::computeCartesianWaypointPath(GraspCandidatePtr& grasp_candida
         std::vector<const robot_state::AttachedBody*> attached_bodies;
         start_state_with_body->getAttachedBodies(attached_bodies);
         for (const auto& ab : attached_bodies)
-          start_state_copy->attachBody(ab->getName(), ab->getShapes(), ab->getFixedTransforms(), ab->getTouchLinks(),
+          start_state_copy->attachBody(ab->getName(), ab->getShapes(), ab->getShapePoses(), ab->getTouchLinks(),
                                        ab->getAttachedLinkName(), ab->getDetachPosture(), ab->getSubframeTransforms());
         constraint_fn = boost::bind(&isGraspStateValid, scene.get(), collision_checking_verbose,
                                     only_check_self_collision, visual_tools_, _1, _2, _3);

--- a/src/grasp_planner.cpp
+++ b/src/grasp_planner.cpp
@@ -346,8 +346,9 @@ bool GraspPlanner::computeCartesianWaypointPath(GraspCandidatePtr& grasp_candida
         std::vector<const robot_state::AttachedBody*> attached_bodies;
         start_state_with_body->getAttachedBodies(attached_bodies);
         for (const auto& ab : attached_bodies)
-          start_state_copy->attachBody(ab->getName(), ab->getShapes(), ab->getShapePoses(), ab->getTouchLinks(),
-                                       ab->getAttachedLinkName(), ab->getDetachPosture(), ab->getSubframeTransforms());
+          start_state_copy->attachBody(ab->getName(), ab->getPose(), ab->getShapes(), ab->getShapePoses(), 
+                                       ab->getTouchLinks(), ab->getAttachedLinkName(), ab->getDetachPosture(), 
+                                       ab->getSubframes());
         constraint_fn = boost::bind(&isGraspStateValid, scene.get(), collision_checking_verbose,
                                     only_check_self_collision, visual_tools_, _1, _2, _3);
       }


### PR DESCRIPTION
The recently merged PR https://github.com/ros-planning/moveit/pull/2037 broke the `RobotState::attachBody` function interface. In detail: https://github.com/ros-planning/moveit/commit/9503bfb84fc3473918f30a1027bd34bfd4492f0d#diff-3cb1e10476cb16e01f6bf70bb8b5c7d86cc0896b0f243bf93e855e05c7c4f6e5

The fix required only two small changes.